### PR TITLE
Fix on-release.yml workflow

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+
 jobs:
   assets:
     runs-on: ubuntu-latest
@@ -16,4 +19,4 @@ jobs:
       - name: Upload assets
         run: gh release upload ${{ github.ref_name }} single_include/upa/*.*
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
* Add `contents: write` permission to fix error: "HTTP 403: Resource not accessible by integration"
* Change the environment variable `GITHUB_TOKEN` to `GH_TOKEN`. See: https://docs.github.com/en/actions/using-workflows/using-github-cli-in-workflows