### PR TITLE
Fix IPv6 handling when converting file URL to UNC path

### DIFF
--- a/test/test-url.cpp
+++ b/test/test-url.cpp
@@ -761,6 +761,9 @@ TEST_CASE("path_from_file_url") {
         CHECK(path_from_file_url("file://host/path", upa::file_path_format::windows) == "\\\\host\\path");
         CHECK(path_from_file_url("file:////host/path", upa::file_path_format::windows) == "\\\\host\\path");
         CHECK(path_from_file_url("file://///host/path", upa::file_path_format::windows) == "\\\\host\\path");
+        // UNC: IPv4 and IPv6 hostnames
+        CHECK(path_from_file_url("file://127.0.0.1/path", upa::file_path_format::windows) == "\\\\127.0.0.1\\path");
+        CHECK(path_from_file_url("file://[::1]/path", upa::file_path_format::windows) == "\\\\--1.ipv6-literal.net\\path");
         // Invalid UNC
         CHECK_THROWS_AS(path_from_file_url("file://host", upa::file_path_format::windows), upa::url_error);
         CHECK_THROWS_AS(path_from_file_url("file://host/", upa::file_path_format::windows), upa::url_error);


### PR DESCRIPTION
The IPv6 address is converted to the UNC-supported IPv6 format: colons are replaced by hyphens and `.ipv6-literal.net` is appended. This is necessary because colons are not valid in UNC path components.

More information:
* https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/62e862f4-2a51-452e-8eeb-dc4ff5ee33cc
* https://en.wikipedia.org/wiki/IPv6_address#Literal_IPv6_addresses_in_UNC_path_names