### PR TITLE
Accept UNC path without share-name

### DIFF
--- a/include/upa/url.h
+++ b/include/upa/url.h
@@ -3050,6 +3050,8 @@ inline const CharT* is_unc_path(const CharT* first, const CharT* last)
                     return nullptr;
                 break;
             }
+            // Accept UNC path with hostname, even if it does not contain share-name
+            end_of_share_name = pcend;
             break;
         case 2:
             // Check the second UNC path component (share name).


### PR DESCRIPTION
Windows File Explorer accepts such UNC paths, and Chrome and Firefox convert them to file URLs.

Example of conversion: `\\host-name` -> `file://host-name/`