### PR TITLE
Add str_arg_char specializations for ATL/MFC and Qt strings

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,6 +4,7 @@ codecov:
 ignore:
   - "deps"
   - "include/upa/idna.h"
+  - "include/upa/url_for_*.h"
   - "src/idna.cpp"
   - "test"
 

--- a/include/upa/url_for_atl.h
+++ b/include/upa/url_for_atl.h
@@ -1,0 +1,24 @@
+// Copyright 2024 Rimas Misevičius
+// Distributed under the BSD-style license that can be
+// found in the LICENSE file.
+//
+#ifndef UPA_URL_FOR_ATL_H
+#define UPA_URL_FOR_ATL_H
+
+#include "url.h" // IWYU pragma: export
+#include <cstringt.h>
+
+namespace upa {
+
+template<typename CharT, class StringTraits>
+struct str_arg_char<ATL::CStringT<CharT, StringTraits>> {
+    using type = CharT;
+
+    static str_arg<CharT> to_str_arg(const ATL::CStringT<CharT, StringTraits>& str) {
+        return { str.GetString(), static_cast<std::ptrdiff_t>(str.GetLength()) };
+    }
+};
+
+} // namespace upa
+
+#endif // UPA_URL_FOR_ATL_H

--- a/include/upa/url_for_qt.h
+++ b/include/upa/url_for_qt.h
@@ -1,0 +1,27 @@
+// Copyright 2024 Rimas Misevičius
+// Distributed under the BSD-style license that can be
+// found in the LICENSE file.
+//
+#ifndef UPA_URL_FOR_QT_H
+#define UPA_URL_FOR_QT_H
+
+#include "url.h" // IWYU pragma: export
+#include <QString>
+
+namespace upa {
+
+template<>
+struct str_arg_char<QString> {
+    using type = char16_t;
+
+    static str_arg<char16_t> to_str_arg(const QString& str) {
+        return {
+            reinterpret_cast<const char16_t*>(str.data()),
+            static_cast<std::ptrdiff_t>(str.length())
+        };
+    }
+};
+
+} // namespace upa
+
+#endif // UPA_URL_FOR_QT_H


### PR DESCRIPTION
To support string input from CStringT (ATL/MFC) and QString (Qt) objects.