### PR TITLE
Fix use of __has_include

### DIFF
--- a/include/upa/url_for_qt.h
+++ b/include/upa/url_for_qt.h
@@ -11,9 +11,12 @@
 
 #include "url.h" // IWYU pragma: export
 #include <QString>
-#if defined(__has_include) && __has_include(<QtVersionChecks>)
+#ifdef __has_include
+#if __has_include(<QtVersionChecks>)
 # include <QtVersionChecks>
-#else
+#endif
+#endif // __has_include
+#ifndef QT_VERSION
 # include <QtGlobal>
 #endif
 #if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)

--- a/test/test-url_for_.cpp
+++ b/test/test-url_for_.cpp
@@ -16,9 +16,12 @@
 #ifdef UPA_TEST_URL_FOR_QT
 # include "upa/url_for_qt.h"
 # include <QString>
-# if defined(__has_include) && __has_include(<QtVersionChecks>)
+# ifdef __has_include
+# if __has_include(<QtVersionChecks>)
 #  include <QtVersionChecks>
-# else
+# endif
+# endif // __has_include
+# ifndef QT_VERSION
 #  include <QtGlobal>
 # endif
 # if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)


### PR DESCRIPTION
Use `__has_include` in a portable way. See:
https://gcc.gnu.org/onlinedocs/cpp/_005f_005fhas_005finclude.html