### PR TITLE
Simplify `str_arg_char` template specialization

### DIFF
--- a/include/upa/url_for_atl.h
+++ b/include/upa/url_for_atl.h
@@ -24,7 +24,7 @@ struct str_arg_char_for_atl {
     using type = typename StrT::XCHAR;
 
     static str_arg<type> to_str_arg(const StrT& str) {
-        return { str.GetString(), static_cast<std::ptrdiff_t>(str.GetLength()) };
+        return { str.GetString(), str.GetLength() };
     }
 };
 

--- a/include/upa/url_for_qt.h
+++ b/include/upa/url_for_qt.h
@@ -22,7 +22,6 @@
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 # include <QUtf8StringView>
 #endif
-#include <cstddef> // std::ptrdiff_t
 
 namespace upa {
 
@@ -33,10 +32,7 @@ struct str_arg_char_for_qt {
     using type = CharT;
 
     static str_arg<type> to_str_arg(const StrT& str) {
-        return {
-            reinterpret_cast<const type*>(str.data()),
-            static_cast<std::ptrdiff_t>(str.length())
-        };
+        return { reinterpret_cast<const type*>(str.data()), str.length() };
     }
 };
 

--- a/test/test-str_arg.cpp
+++ b/test/test-str_arg.cpp
@@ -13,11 +13,9 @@
 
 // Function to test
 
-using namespace upa;
-
-template <class ...Args, enable_if_str_arg_t<Args...> = 0>
-inline std::size_t procfn(Args&&... args) {
-    const auto inp = make_str_arg(std::forward<Args>(args)...);
+template <class StrT, upa::enable_if_str_arg_t<StrT> = 0>
+inline std::size_t procfn(StrT&& str) {
+    const auto inp = upa::make_str_arg(std::forward<StrT>(str));
     return std::distance(inp.begin(), inp.end());
 }
 
@@ -54,7 +52,7 @@ struct str_arg_char<CustomString<CharT>> {
 
 template <class CharT>
 inline void test_char() {
-    const size_t N = 3;
+    const std::size_t N = 3;
     CharT arr[] = { '1', '2', '3', 0 };
     const CharT carr[] = { '1', '2', '3', 0 };
     CharT* ptr = arr;
@@ -67,30 +65,33 @@ inline void test_char() {
     procfn(cptr);
     procfn(vptr);
 
-    procfn(arr, N);
-    procfn(carr, N);
-    procfn(ptr, N);
-    procfn(cptr, N);
-    procfn(vptr, N);
+    // upa::str_arg
+    upa::str_arg<CharT> arg(arr);
+    procfn(arg);
+    const upa::str_arg<CharT> carg(arr);
+    procfn(carg);
 
+    procfn(upa::str_arg<CharT>{arr, N});
+    procfn(upa::str_arg<CharT>{carr, N});
+    procfn(upa::str_arg<CharT>{ptr, N});
+    procfn(upa::str_arg<CharT>{cptr, N});
+    procfn(upa::str_arg<CharT>{vptr, N});
     // int size
-    procfn(arr, int(N));
-    procfn(cptr, int(N));
+    procfn(upa::str_arg<CharT>(arr, static_cast<int>(N)));
+    procfn(upa::str_arg<CharT>(cptr, static_cast<int>(N)));
 
-    procfn(arr, arr + N);
-    procfn(carr, carr + N);
-    procfn(ptr, ptr + N);
-    procfn(cptr, cptr + N);
-    procfn(vptr, vptr + N);
+    procfn(upa::str_arg<CharT>{arr, arr + N});
+    procfn(upa::str_arg<CharT>{carr, carr + N});
+    procfn(upa::str_arg<CharT>{ptr, ptr + N});
+    procfn(upa::str_arg<CharT>{cptr, cptr + N});
+    procfn(upa::str_arg<CharT>{vptr, vptr + N});
 
+    // std::basic_string
     const std::basic_string<CharT> str(arr);
     procfn(str);
     procfn(std::basic_string<CharT>(arr));
 
-    upa::str_arg<CharT> arg(arr);
-    procfn(arg);
-
-    // test custom string
+    // custom string
     procfn(CustomString<CharT>{cptr, N});
 }
 

--- a/test/test-str_arg.cpp
+++ b/test/test-str_arg.cpp
@@ -66,30 +66,30 @@ inline void test_char() {
     procfn(vptr);
 
     // upa::str_arg
-    upa::str_arg<CharT> arg(arr);
+    upa::str_arg<CharT> arg{ arr };
     procfn(arg);
-    const upa::str_arg<CharT> carg(arr);
+    const upa::str_arg carg{ arr };
     procfn(carg);
 
-    procfn(upa::str_arg<CharT>{arr, N});
-    procfn(upa::str_arg<CharT>{carr, N});
-    procfn(upa::str_arg<CharT>{ptr, N});
-    procfn(upa::str_arg<CharT>{cptr, N});
-    procfn(upa::str_arg<CharT>{vptr, N});
+    procfn(upa::str_arg{ arr, N });
+    procfn(upa::str_arg{ carr, N });
+    procfn(upa::str_arg{ ptr, N });
+    procfn(upa::str_arg{ cptr, N });
+    procfn(upa::str_arg{ vptr, N });
     // int size
-    procfn(upa::str_arg<CharT>(arr, static_cast<int>(N)));
-    procfn(upa::str_arg<CharT>(cptr, static_cast<int>(N)));
+    procfn(upa::str_arg{ arr, static_cast<int>(N) });
+    procfn(upa::str_arg{ cptr, static_cast<int>(N) });
 
-    procfn(upa::str_arg<CharT>{arr, arr + N});
-    procfn(upa::str_arg<CharT>{carr, carr + N});
-    procfn(upa::str_arg<CharT>{ptr, ptr + N});
-    procfn(upa::str_arg<CharT>{cptr, cptr + N});
-    procfn(upa::str_arg<CharT>{vptr, vptr + N});
+    procfn(upa::str_arg{ arr, arr + N });
+    procfn(upa::str_arg{ carr, carr + N });
+    procfn(upa::str_arg{ ptr, ptr + N });
+    procfn(upa::str_arg{ cptr, cptr + N });
+    procfn(upa::str_arg{ vptr, vptr + N });
 
     // std::basic_string
-    const std::basic_string<CharT> str(arr);
+    const std::basic_string<CharT> str{ arr };
     procfn(str);
-    procfn(std::basic_string<CharT>(arr));
+    procfn(std::basic_string<CharT>{ arr });
 
     // custom string
     procfn(CustomString<CharT>{cptr, N});


### PR DESCRIPTION
* One string class parameter is used instead of the parameter pack
* Simplified use of the `str_arg` constructor with string pointer and length parameters - length can now be any integer.
* Use class template argument deduction with `str_arg` in `test-str_arg.cpp`.