### PR TITLE
Improve support for string input

### DIFF
--- a/include/upa/str_arg.h
+++ b/include/upa/str_arg.h
@@ -131,19 +131,19 @@ namespace detail {
     template<class>
     auto test_data(long) -> void;
 
-    // test class T has length() member
+    // test class T has size() member
     template<class T>
-    auto test_length(int) -> decltype(std::declval<T>().length());
+    auto test_size(int) -> decltype(std::declval<T>().size());
     template<class>
-    auto test_length(long) -> void;
+    auto test_size(long) -> void;
 
     // T::data() return type (void - if no such member)
     template<class T>
     using data_member_t = decltype(detail::test_data<T>(0));
 
-    // T::length() return type (void - if no such member)
+    // T::size() return type (void - if no such member)
     template<class T>
-    using length_member_t = decltype(detail::test_length<T>(0));
+    using size_member_t = decltype(detail::test_size<T>(0));
 } // namespace detail
 
 
@@ -162,16 +162,16 @@ struct str_arg_char<CharT*> : std::remove_cv<CharT> {
     }
 };
 
-// String that has data() and length() members
+// String that has data() and size() members
 template<class StrT>
 struct str_arg_char<StrT> : std::enable_if<
     std::is_pointer_v<detail::data_member_t<StrT>> &&
-    is_size_type_v<detail::length_member_t<StrT>>,
+    is_size_type_v<detail::size_member_t<StrT>>,
     remove_cvptr_t<detail::data_member_t<StrT>>> {
 
     template <class STR, typename T = typename STR::value_type>
     static str_arg<T> to_str_arg(const STR& str) {
-        return { str.data(), str.length() };
+        return { str.data(), str.size() };
     }
 };
 

--- a/include/upa/str_arg.h
+++ b/include/upa/str_arg.h
@@ -49,6 +49,12 @@ constexpr bool is_size_type_v =
     std::is_convertible_v<SizeT, std::size_t> ||
     std::is_convertible_v<SizeT, std::ptrdiff_t>;
 
+// See: https://en.cppreference.com/w/cpp/concepts/derived_from
+template<class Derived, class Base>
+constexpr bool is_derived_from_v =
+    std::is_base_of_v<Base, Derived> &&
+    std::is_convertible_v<const volatile Derived*, const volatile Base*>;
+
 
 // string args helper class
 

--- a/include/upa/url_for_atl.h
+++ b/include/upa/url_for_atl.h
@@ -14,7 +14,7 @@
 #ifdef UPA_CPP_20
 # include <concepts>
 #else
-# include <cstringt.h>
+# include <type_traits>
 #endif
 
 namespace upa {
@@ -43,17 +43,14 @@ struct str_arg_char<StrT> : public str_arg_char_for_atl<StrT> {};
 
 #else // UPA_CPP_20
 
-template<typename CharT, bool mfcdll>
-struct str_arg_char<ATL::CSimpleStringT<CharT, mfcdll>> :
-    public str_arg_char_for_atl<ATL::CSimpleStringT<CharT, mfcdll>> {};
-
-template<typename CharT, class StringTraits>
-struct str_arg_char<ATL::CStringT<CharT, StringTraits>> :
-    public str_arg_char_for_atl<ATL::CStringT<CharT, StringTraits>> {};
-
-template<class StrT, int nChars>
-struct str_arg_char<ATL::CFixedStringT<StrT, nChars>> :
-    public str_arg_char_for_atl<ATL::CFixedStringT<StrT, nChars>> {};
+// CStringT and CFixedStringT are derived from CSimpleStringT
+template<class StrT>
+struct str_arg_char<StrT, std::enable_if_t<
+    is_derived_from_v<StrT, ATL::CSimpleStringT<char, true>> ||
+    is_derived_from_v<StrT, ATL::CSimpleStringT<wchar_t, true>> ||
+    is_derived_from_v<StrT, ATL::CSimpleStringT<char, false>> ||
+    is_derived_from_v<StrT, ATL::CSimpleStringT<wchar_t, false>>
+    >> : public str_arg_char_for_atl<StrT> {};
 
 #endif // UPA_CPP_20
 

--- a/include/upa/url_for_qt.h
+++ b/include/upa/url_for_qt.h
@@ -10,12 +10,17 @@
 #define UPA_URL_FOR_QT_H
 
 #include "url.h" // IWYU pragma: export
-#include <QString>
 #if __has_include(<QtVersionChecks>)
 # include <QtVersionChecks>
 #else
 # include <QtGlobal>
 #endif
+
+// As of version 6.7, Qt string classes are convertible to
+// std::basic_string_view, and such strings are supported in the
+// str_arg.h file.
+#if QT_VERSION < QT_VERSION_CHECK(6, 7, 0)
+#include <QString>
 #if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
 # include <QStringView>
 #endif
@@ -32,7 +37,7 @@ struct str_arg_char_for_qt {
     using type = CharT;
 
     static str_arg<type> to_str_arg(const StrT& str) {
-        return { reinterpret_cast<const type*>(str.data()), str.length() };
+        return { reinterpret_cast<const type*>(str.data()), str.size() };
     }
 };
 
@@ -53,5 +58,7 @@ struct str_arg_char<QUtf8StringView> :
 #endif
 
 } // namespace upa
+
+#endif // QT_VERSION < QT_VERSION_CHECK(6, 7, 0)
 
 #endif // UPA_URL_FOR_QT_H

--- a/test/test-str_arg.cpp
+++ b/test/test-str_arg.cpp
@@ -21,6 +21,20 @@ inline std::size_t procfn(StrT&& str) {
     return std::distance(inp.begin(), inp.end());
 }
 
+// Custom string class convertible to std::basic_string_view
+
+template <typename CharT>
+class ConvertibleString {
+public:
+    ConvertibleString(const CharT* data, std::size_t length)
+        : data_(data), length_(length) {}
+    operator std::basic_string_view<CharT>() const noexcept {
+        return { data_, length_ };
+    }
+private:
+    const CharT* data_ = nullptr;
+    std::size_t length_ = 0;
+};
 
 // Custom string class and it's specialization
 
@@ -97,7 +111,8 @@ inline void test_char() {
     procfn(str);
     procfn(std::basic_string<CharT>{ arr });
 
-    // custom string
+    // custom strings
+    procfn(ConvertibleString<CharT>{cptr, N});
     procfn(CustomString<CharT>{cptr, N});
 }
 

--- a/test/test-str_arg.cpp
+++ b/test/test-str_arg.cpp
@@ -9,6 +9,8 @@
 
 #include "upa/str_arg.h"
 //#include "doctest-main.h"
+#include <array>
+#include <vector>
 
 
 // Function to test
@@ -85,6 +87,10 @@ inline void test_char() {
     procfn(upa::str_arg{ ptr, ptr + N });
     procfn(upa::str_arg{ cptr, cptr + N });
     procfn(upa::str_arg{ vptr, vptr + N });
+
+    // has data() and size() members
+    procfn(std::array<CharT, N>{ '1', '2', '3'});
+    procfn(std::vector<CharT>{ '1', '2', '3'});
 
     // std::basic_string
     const std::basic_string<CharT> str{ arr };


### PR DESCRIPTION
* Support strings that have `data()` and `size()` members of supported types. This allows other containers (e.g. `std::vector`) to be used as input.
* Added support for strings that are convertible to `std::basic_string_view` (e.g. `QString` from Qt 6.7 or later).
* Improved ATL/MFC string input support for C++17: accept any string derived from `CSimpleStringT`.