### PR TITLE
Add `upa::domain_to_unicode` function

### DIFF
--- a/include/upa/url_host.h
+++ b/include/upa/url_host.h
@@ -177,17 +177,16 @@ inline bool domain_to_unicode(std::basic_string<CharT>& output, StrT&& input,
         std::u32string domain;
         const bool res = idna::domain_to_unicode(domain, inp.begin(), inp.end(), be_strict, is_input_ascii);
         if constexpr (sizeof(CharT) == sizeof(char)) {
-            // char8_t, or char
+            // CharT is char8_t, or char
             for (auto cp : domain)
                 url_utf::append_utf8<std::basic_string<CharT>, detail::append_to_string>(cp, output);
         } else if constexpr (sizeof(CharT) == sizeof(char16_t)) {
-            // char16_t, or wchar_t Windows
+            // CharT is char16_t, or wchar_t (Windows)
             for (auto cp : domain)
                 url_utf::append_utf16(cp, output);
         } else if constexpr (sizeof(CharT) == sizeof(char32_t)) {
-            // wchar_t non Windows
-            for (auto cp : domain)
-                output.push_back(static_cast<CharT>(cp));
+            // CharT is wchar_t (non Windows)
+            util::append(output, domain);
         } else {
             static_assert(util::false_v<CharT>, "unsupported output character type");
         }

--- a/include/upa/url_host.h
+++ b/include/upa/url_host.h
@@ -189,7 +189,7 @@ inline bool domain_to_unicode(std::basic_string<CharT>& output, StrT&& input,
             for (auto cp : domain)
                 output.push_back(static_cast<CharT>(cp));
         } else {
-            static_assert(false, "unsupported output character type");
+            static_assert(util::false_v<CharT>, "unsupported output character type");
         }
         return res;
     }

--- a/include/upa/url_utf.h
+++ b/include/upa/url_utf.h
@@ -29,10 +29,8 @@ public:
     template <class Output, void appendByte(unsigned char, Output&)>
     static void append_utf8(uint32_t code_point, Output& output);
 
-/*** UNUSED ***
     template <class Output>
     static void append_utf16(uint32_t code_point, Output& output);
-***/
 
     // Convert to utf-8 string
     static std::string to_utf8_string(const char16_t* first, const char16_t* last);
@@ -99,8 +97,9 @@ constexpr detail::result_value<uint32_t> url_utf::read_utf_char(const CharT*& fi
 }
 
 namespace detail {
-    inline void append_to_string(uint8_t c, std::string& str) {
-        str.push_back(static_cast<char>(c));
+    template <typename CharT>
+    inline void append_to_string(uint8_t c, std::basic_string<CharT>& str) {
+        str.push_back(static_cast<CharT>(c));
     };
 } // namespace detail
 
@@ -257,7 +256,6 @@ inline void url_utf::append_utf8(uint32_t code_point, Output& output) {
     }
 }
 
-/*** UNUSED ***
 // Modified version of the U16_APPEND_UNSAFE macro in utf16.h from ICU
 //
 // It converts code_point to UTF-16 code units sequence and appends to output.
@@ -272,7 +270,6 @@ inline void url_utf::append_utf16(uint32_t code_point, Output& output) {
         output.push_back(static_cast<char16_t>((code_point & 0x3ff) | 0xdc00));
     }
 }
-***/
 
 
 } // namespace upa

--- a/include/upa/util.h
+++ b/include/upa/util.h
@@ -16,6 +16,11 @@
 
 namespace upa::util {
 
+// For use in static_assert, workaround before CWG2518/P2593R1
+
+template<class>
+constexpr bool false_v = false;
+
 // Integers
 
 // Some functions here use unsigned arithmetics with unsigned overflow intentionally.

--- a/include/upa/util.h
+++ b/include/upa/util.h
@@ -107,14 +107,14 @@ constexpr std::size_t add_sizes(std::size_t size1, std::size_t size2, std::size_
     return size1 + size2;
 }
 
-template <class StrT>
-inline void append(std::string& dest, const StrT& src) {
+template <class CharT, class StrT>
+inline void append(std::basic_string<CharT>& dest, const StrT& src) {
 #ifdef _MSC_VER
-    if constexpr (!std::is_same_v<typename StrT::value_type, char>) {
+    if constexpr (!std::is_same_v<typename StrT::value_type, CharT>) {
         // the value_type of dest and src are different
         dest.reserve(add_sizes(dest.size(), src.size(), dest.max_size()));
         for (const auto c : src)
-            dest.push_back(static_cast<char>(c));
+            dest.push_back(static_cast<CharT>(c));
     } else
 #endif
     dest.append(src.begin(), src.end());

--- a/test/test-url_host.cpp
+++ b/test/test-url_host.cpp
@@ -247,28 +247,23 @@ TEST_SUITE("url_host") {
     }
 }
 
-#if 0
-
 // Test upa::domain_to_unicode function
 
-TEST_SUITE("domain_to_unicode") {
-    TEST_CASE("Valid input") {
-        upa::simple_buffer<char> output;
-        CHECK(upa::domain_to_unicode("abc", 3, output) == upa::validation_errc::ok);
-        CHECK(upa::string_view(output.data(), output.size()) == "abc");
+TEST_CASE_TEMPLATE_DEFINE("domain_to_unicode", CharT, test_domain_to_unicode) {
+    SUBCASE("Valid input") {
+        const std::basic_string<CharT> input{ 'a', 'b', 'c' };
+        std::basic_string<CharT> output;
+        CHECK(upa::domain_to_unicode(output, input));
+        CHECK(output == input);
     }
 
-    TEST_CASE("Valid long input") {
-        const std::string input = long_host();
-        upa::simple_buffer<char> output;
-        CHECK(upa::domain_to_unicode(input.data(), input.length(), output) == upa::validation_errc::ok);
-    }
-
-    TEST_CASE("Invalid input") {
-        upa::simple_buffer<char> output;
-        // IDNA errors are not failures for this function, so it returns `ok`
-        CHECK(upa::domain_to_unicode("xn--a.op", 8, output) == upa::validation_errc::ok);
+    SUBCASE("Invalid input") {
+        std::basic_string<CharT> output;
+        CHECK_FALSE(upa::domain_to_unicode(output, "xn--a.op"));
     }
 }
 
+TEST_CASE_TEMPLATE_INVOKE(test_domain_to_unicode, char, wchar_t, char16_t, char32_t);
+#ifdef __cpp_char8_t
+TEST_CASE_TEMPLATE_INVOKE(test_domain_to_unicode, char8_t);
 #endif

--- a/test/test-utf.cpp
+++ b/test/test-utf.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2023 Rimas Misevičius
+// Copyright 2016-2024 Rimas Misevičius
 // Distributed under the BSD-style license that can be
 // found in the LICENSE file.
 //
@@ -8,14 +8,12 @@
 #include "doctest-main.h"
 
 
-using namespace upa;
-
 template <typename T>
 static uint32_t first_codepoint(T&& strUtf) {
-    const auto inp = make_str_arg(strUtf);
+    const auto inp = upa::make_str_arg(strUtf);
     const auto* first = inp.begin();
     const auto* last = inp.end();
-    return url_utf::read_utf_char(first, last).value;
+    return upa::url_utf::read_utf_char(first, last).value;
 }
 
 TEST_CASE("url_utf::read_utf_char with UTF-8") {
@@ -37,4 +35,17 @@ TEST_CASE("url_utf::read_utf_char with invalid UTF-8") {
     // must return U+FFFD - REPLACEMENT CHARACTER
     CHECK(first_codepoint(std::string{ char(0xC2), char('x') }) == 0xFFFD);
     CHECK(first_codepoint(std::string{ char(0xF0), char(0x90), char('x') }) == 0xFFFD);
+}
+
+TEST_CASE("url_utf::append_utf16") {
+    static constexpr auto to_utf16 = [](char32_t cp) {
+        std::u16string output;
+        upa::url_utf::append_utf16(cp, output);
+        return output;
+    };
+
+    CHECK(to_utf16(0xFFFF) == u"\uFFFF");
+    // U+10000..U+10FFFF
+    CHECK(to_utf16(0x10000) == u"\U00010000");
+    CHECK(to_utf16(0x10FFFF) == u"\U0010FFFF");
 }


### PR DESCRIPTION
The output of this function can be of type `std::string`, `std::wstring`, `std::u8string`, `std::u16string`, or `std::u32string`.