### PR TITLE
Simplify `util::append` by using constexpr if

### DIFF
--- a/include/upa/url_host.h
+++ b/include/upa/url_host.h
@@ -1,4 +1,4 @@
-// Copyright 2016-2024 Rimas Misevičius
+// Copyright 2016-2025 Rimas Misevičius
 // Distributed under the BSD-style license that can be
 // found in the LICENSE file.
 //
@@ -287,7 +287,7 @@ inline validation_errc host_parser::parse_host(const CharT* first, const CharT* 
     if (dest.need_save()) {
         // Return asciiDomain
         std::string& str_host = dest.hostStart();
-        util::append(str_host, buff_ascii);
+        str_host.append(buff_ascii);
         dest.hostDone(HostType::Domain);
     }
     return validation_errc::ok;

--- a/include/upa/util.h
+++ b/include/upa/util.h
@@ -1,4 +1,4 @@
-// Copyright 2016-2024 Rimas Misevičius
+// Copyright 2016-2025 Rimas Misevičius
 // Distributed under the BSD-style license that can be
 // found in the LICENSE file.
 //
@@ -102,28 +102,18 @@ constexpr std::size_t add_sizes(std::size_t size1, std::size_t size2, std::size_
     return size1 + size2;
 }
 
-#ifdef _MSC_VER
-// the value_type of dest and src are the same (char)
-template <class StrT,
-    std::enable_if_t<std::is_same_v<typename StrT::value_type, char>, int> = 0>
-inline void append(std::string& dest, const StrT& src) {
-    dest.append(src.begin(), src.end());
-}
-
-// the value_type of dest and src are different
-template <class StrT,
-    std::enable_if_t<!std::is_same_v<typename StrT::value_type, char>, int> = 0>
-inline void append(std::string& dest, const StrT& src) {
-    dest.reserve(add_sizes(dest.size(), src.size(), dest.max_size()));
-    for (const auto c : src)
-        dest.push_back(static_cast<char>(c));
-}
-#else
 template <class StrT>
 inline void append(std::string& dest, const StrT& src) {
+#ifdef _MSC_VER
+    if constexpr (!std::is_same_v<typename StrT::value_type, char>) {
+        // the value_type of dest and src are different
+        dest.reserve(add_sizes(dest.size(), src.size(), dest.max_size()));
+        for (const auto c : src)
+            dest.push_back(static_cast<char>(c));
+    } else
+#endif
     dest.append(src.begin(), src.end());
 }
-#endif
 
 template <class CharT, class UnaryOperation>
 inline void append_tr(std::string& dest, const CharT* first, const CharT* last, UnaryOperation unary_op) {

--- a/test/test-url.cpp
+++ b/test/test-url.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2024 Rimas Misevičius
+// Copyright 2016-2025 Rimas Misevičius
 // Distributed under the BSD-style license that can be
 // found in the LICENSE file.
 //
@@ -601,6 +601,40 @@ TEST_CASE("Invalid UTF-32 in hostname") {
     CHECK_THROWS_AS(upa::url{ szUrl1 }, upa::url_error);
     CHECK_THROWS_AS(upa::url{ szUrl2 }, upa::url_error);
     CHECK_THROWS_AS(upa::url{ szUrl3 }, upa::url_error);
+}
+
+// UTF-16 URL input
+
+TEST_CASE("UTF-16 URL input") {
+    static const char16_t szUrl[] = u"ws://u:p@h:8080/pa/th?q#f";
+
+    upa::url url;
+    REQUIRE(upa::success(url.parse(szUrl)));
+    CHECK(url.protocol() == "ws:");
+    CHECK(url.username() == "u");
+    CHECK(url.password() == "p");
+    CHECK(url.hostname() == "h");
+    CHECK(url.port() == "8080");
+    CHECK(url.pathname() == "/pa/th");
+    CHECK(url.search() == "?q");
+    CHECK(url.hash() == "#f");
+}
+
+// UTF-32 URL input
+
+TEST_CASE("UTF-32 URL input") {
+    static const char32_t szUrl[] = U"ws://u:p@h:8080/pa/th?q#f";
+
+    upa::url url;
+    REQUIRE(upa::success(url.parse(szUrl)));
+    CHECK(url.protocol() == "ws:");
+    CHECK(url.username() == "u");
+    CHECK(url.password() == "p");
+    CHECK(url.hostname() == "h");
+    CHECK(url.port() == "8080");
+    CHECK(url.pathname() == "/pa/th");
+    CHECK(url.search() == "?q");
+    CHECK(url.hash() == "#f");
 }
 
 // URL utilities


### PR DESCRIPTION
Add tests with UTF-16 and UTF-32 input.