### PR TITLE
Implement the Public Suffix List algorithm

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,6 +10,9 @@ ignore:
 
 coverage:
   status:
+    patch:
+      default:
+        target: 95%
     project:
       default:
         threshold: 0.5%

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -19,7 +19,7 @@ jobs:
             cxx_standard: 17
             cmake_options: "-DUPA_BUILD_BENCH=ON"
             after_test: |
-              build/bench-public_suffix_list
+              build/bench-public_suffix_list test/psl
               build/bench-url test/wpt/urltestdata.json
 
     steps:

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -19,6 +19,7 @@ jobs:
             cxx_standard: 17
             cmake_options: "-DUPA_BUILD_BENCH=ON"
             after_test: |
+              build/bench-public_suffix_list
               build/bench-url test/wpt/urltestdata.json
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /examples/extracted-cpp/*.cpp
 
 # downloadable tests directory
+/test/psl/
 /test/wpt/
 
 # Visual Studio

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,7 @@ if (UPA_BUILD_TESTS OR UPA_BUILD_BENCH OR UPA_BUILD_FUZZER OR UPA_BUILD_EXAMPLES
   else()
     add_library(${upa_lib_target} STATIC
       src/idna.cpp
+      src/public_suffix_list.cpp
       src/url.cpp
       src/url_ip.cpp
       src/url_percent_encode.cpp
@@ -155,6 +156,7 @@ if (UPA_BUILD_TESTS)
       test/test-buffer.cpp
       test/test-ipv4.cpp
       test/test-ipv6.cpp
+      test/test-public_suffix_list.cpp
       test/test-str_arg.cpp
       test/test-utf.cpp
       test/test-util.cpp

--- a/Doxyfile
+++ b/Doxyfile
@@ -996,6 +996,7 @@ INPUT                  = include/upa/url.h \
                          include/upa/url_result.h \
                          include/upa/url_search_params.h \
                          include/upa/url_percent_encode.h \
+                         include/upa/public_suffix_list.h \
                          README.md \
                          doc/string_input.md
 

--- a/include/upa/public_suffix_list.h
+++ b/include/upa/public_suffix_list.h
@@ -48,6 +48,10 @@ constexpr std::size_t get_label_pos_by_index(StrT&& str_host, std::size_t index)
 // public_suffix_list class
 
 class public_suffix_list {
+    // label_item::code values
+    static constexpr std::uint8_t DIFF_MASK = 3;
+    static constexpr std::uint8_t IS_ICANN = 4;
+    static constexpr std::uint8_t IS_PRIVATE = 8;
 public:
     enum class option {
         PUBLIC_SUFFIX = 0,
@@ -63,11 +67,21 @@ public:
 #endif
 
     struct result {
-        constexpr operator bool() const {
+        constexpr operator bool() const noexcept {
             return first_label_ind != static_cast<std::size_t>(-1);
+        }
+        constexpr bool is_icann() const noexcept {
+            return (code_ & IS_ICANN) != 0;
+        }
+        constexpr bool is_private() const noexcept {
+            return (code_ & IS_PRIVATE) != 0;
+        }
+        constexpr bool wildcard_rule() const noexcept {
+            return (code_ & DIFF_MASK) == 3;
         }
         std::size_t first_label_ind = static_cast<std::size_t>(-1);
         std::size_t first_label_pos = static_cast<std::size_t>(-1);
+        std::uint8_t code_ = 0;
     };
 
     // Load public suffix list from file
@@ -182,10 +196,6 @@ private:
 
         std::uint8_t code = 0;
         std::unique_ptr<map_type> children;
-
-        static constexpr std::uint8_t DIFF_MASK = 3;
-        static constexpr std::uint8_t IS_ICANN = 4;
-        static constexpr std::uint8_t IS_PRIVATE = 8;
     };
 
     label_item root_;

--- a/include/upa/public_suffix_list.h
+++ b/include/upa/public_suffix_list.h
@@ -102,7 +102,7 @@ public:
 
     // Get public suffix or registrable domain
     template <class StrT, enable_if_str_arg_t<StrT> = 0>
-    std::string get_suffix(StrT&& str_host, option opt) const {
+    std::string get_suffix(StrT&& str_host, option opt = PUBLIC_SUFFIX) const {
         try {
             return std::string{ get_suffix_view(
                 upa::url_host{ std::forward<StrT>(str_host) },
@@ -113,20 +113,20 @@ public:
         }
     }
 
-    result get_suffix_info(const url& url, option opt) const {
+    result get_suffix_info(const url& url, option opt = PUBLIC_SUFFIX) const {
         if (url.host_type() == HostType::Domain)
             return get_host_suffix_info(url.hostname(), opt);
         return {};
     }
 
-    result get_suffix_info(const url_host& host, option opt) const {
+    result get_suffix_info(const url_host& host, option opt = PUBLIC_SUFFIX) const {
         if (host.type() == HostType::Domain)
             return get_host_suffix_info(host.name(), opt);
         return {};
     }
 
     template <class StrT, enable_if_str_arg_t<StrT> = 0>
-    result get_suffix_info(StrT&& str_host, option opt) const {
+    result get_suffix_info(StrT&& str_host, option opt = PUBLIC_SUFFIX) const {
         try {
             auto res = get_suffix_info(upa::url_host{ std::forward<StrT>(str_host) }, opt);
             res.first_label_pos = get_label_pos_by_index(str_host, res.first_label_ind);
@@ -137,20 +137,20 @@ public:
         }
     }
 
-    std::string_view get_suffix_view(const url& url, option opt) const {
+    std::string_view get_suffix_view(const url& url, option opt = PUBLIC_SUFFIX) const {
         if (url.host_type() == HostType::Domain)
             return get_host_suffix_view(url.hostname(), opt);
         return {};
     }
 
-    std::string_view get_suffix_view(const url_host& host, option opt) const {
+    std::string_view get_suffix_view(const url_host& host, option opt = PUBLIC_SUFFIX) const {
         if (host.type() == HostType::Domain)
             return get_host_suffix_view(host.name(), opt);
         return {};
     }
 
     template <class StrT, enable_if_str_arg_t<StrT> = 0>
-    auto get_suffix_view(StrT&& str_host, option opt) const
+    auto get_suffix_view(StrT&& str_host, option opt = PUBLIC_SUFFIX) const
         -> std::basic_string_view<typename str_arg<str_arg_char_t<StrT>>::value_type> {
         try {
             const auto arg = make_str_arg(std::forward<StrT>(str_host));
@@ -165,6 +165,10 @@ public:
         }
         catch (const upa::url_error&) {}
         return {};
+    }
+
+    bool operator==(const public_suffix_list& b) const {
+        return root_ == b.root_;
     }
 
 private:
@@ -196,6 +200,12 @@ private:
 
         std::uint8_t code = 0;
         std::unique_ptr<map_type> children;
+
+        bool operator==(const label_item& b) const {
+            return code == b.code && (
+                (!children && !b.children) ||
+                (children && b.children && *children == *b.children));
+        }
     };
 
     label_item root_;

--- a/include/upa/public_suffix_list.h
+++ b/include/upa/public_suffix_list.h
@@ -1,0 +1,75 @@
+// Copyright 2024 Rimas Misevičius
+// Distributed under the BSD-style license that can be
+// found in the LICENSE file.
+//
+#ifndef UPA_PUBLIC_SUFFIX_LIST_H
+#define UPA_PUBLIC_SUFFIX_LIST_H
+
+#include "url.h"
+#include <cstddef>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+
+namespace upa {
+
+class public_suffix_list {
+public:
+    template <typename CharT>
+    bool load(const CharT* filename) {
+        std::ifstream finp(filename, std::ios_base::in | std::ios_base::binary);
+        return finp && load(finp);
+    }
+    bool load(std::istream& input);
+
+    template <class StrT, enable_if_str_arg_t<StrT> = 0>
+    std::string get_suffix(StrT&& str_host, bool reg_domain) const {
+        try {
+            return get_host_suffix(upa::url_host{ std::forward<StrT>(str_host) }.to_string(), reg_domain);
+        }
+        catch (const upa::url_error&) {
+            return {};
+        }
+    }
+
+    std::string get_suffix(const url& url, bool reg_domain) const {
+        return get_host_suffix(url.hostname(), reg_domain);
+    }
+
+private:
+    std::string get_host_suffix(std::string_view hostname, bool reg_domain) const;
+
+private:
+    struct label_item {
+#ifdef __cpp_lib_generic_unordered_lookup
+        // https://en.cppreference.com/w/cpp/container/unordered_map/find
+        struct string_hash {
+            using hash_type = std::hash<std::string_view>;
+            using is_transparent = void;
+
+            std::size_t operator()(const char* str) const { return hash_type{}(str); }
+            std::size_t operator()(std::string_view str) const { return hash_type{}(str); }
+            std::size_t operator()(std::string const& str) const { return hash_type{}(str); }
+        };
+        using map_type = std::unordered_map<std::string, label_item, string_hash, std::equal_to<>>;
+#else
+        using map_type = std::unordered_map<std::string, label_item>;
+#endif
+
+        std::uint8_t code = 0;
+        std::unique_ptr<map_type> children;
+
+        static constexpr std::uint8_t DIFF_MASK = 3;
+        static constexpr std::uint8_t IS_ICANN = 4;
+        static constexpr std::uint8_t IS_PRIVATE = 8;
+    };
+
+    label_item root_;
+};
+
+} // namespace upa
+
+#endif // UPA_PUBLIC_SUFFIX_LIST_H

--- a/include/upa/public_suffix_list.h
+++ b/include/upa/public_suffix_list.h
@@ -18,13 +18,24 @@ namespace upa {
 
 class public_suffix_list {
 public:
+    // Load public suffix list from file
     template <typename CharT>
     bool load(const CharT* filename) {
         std::ifstream finp(filename, std::ios_base::in | std::ios_base::binary);
         return finp && load(finp);
     }
-    bool load(std::istream& input);
+    bool load(std::istream& input_stream);
 
+    // Push interface to load public suffix list 
+    struct push_context {
+        std::string remaining{};
+        std::uint8_t code_flags = 0;
+    };
+    void push_line(push_context& ctx, std::string_view line);
+    void push(push_context& ctx, std::string_view buff);
+    bool finalize(push_context& ctx);
+
+    // Get public suffix or registrable domain
     template <class StrT, enable_if_str_arg_t<StrT> = 0>
     std::string get_suffix(StrT&& str_host, bool reg_domain) const {
         try {

--- a/include/upa/public_suffix_list.h
+++ b/include/upa/public_suffix_list.h
@@ -17,8 +17,14 @@
 
 namespace upa {
 
-// get label position in hostname by it's index
-
+/// @brief Get label position in hostname by it's index
+///
+/// The label separator can be any of the following characters: U+002E (.),
+/// U+3002, U+FF0E, U+FF61 (they are mapped to U+002E (.) by IDNA).
+///
+/// @param[in] str_host hostname string
+/// @param[in] index zero-based label index starting from the leftmost label
+/// @return label position in the @p str_host string
 template <class StrT, enable_if_str_arg_t<StrT> = 0>
 constexpr std::size_t get_label_pos_by_index(StrT&& str_host, std::size_t index) {
     const auto inp = make_str_arg(std::forward<StrT>(str_host));
@@ -45,18 +51,49 @@ constexpr std::size_t get_label_pos_by_index(StrT&& str_host, std::size_t index)
     return static_cast<std::size_t>(ptr - first);
 }
 
-// public_suffix_list class
-
+/// @brief The Public Suffix List class
+///
+/// It contains functions for loading Public Suffix List, getting public suffix
+/// or registrable domain of hostname or getting information about them.
+///
+/// It implements the [Public Suffix List](https://publicsuffix.org/) algorithm defined
+/// here: https://github.com/publicsuffix/list/wiki/Format#formal-algorithm.
+/// It also implements the URL standard
+/// [public suffix](https://url.spec.whatwg.org/#host-public-suffix) and
+/// [registrable domain](https://url.spec.whatwg.org/#host-registrable-domain)
+/// algorithms.
+///
+/// The Public Suffix List file `public_suffix_list.dat` is required and can be obtained from
+/// https://publicsuffix.org/list/ or https://github.com/publicsuffix/list.
+///
+/// @par Example
+/// @code
+/// #include "upa/public_suffix_list.h"
+/// #include <iostream>
+///
+/// int main() {
+///     upa::public_suffix_list psl;
+///     if (psl.load("public_suffix_list.dat")) {
+///         auto input = "upa-url.github.io";
+///         auto suffix = psl.get_suffix_view(input);
+///         std::cout << "Public suffix of " << input << " is " << suffix << '\n';
+///     }
+/// }
+/// @endcode
 class public_suffix_list {
     // label_item::code values
     static constexpr std::uint8_t DIFF_MASK = 3;
     static constexpr std::uint8_t IS_ICANN = 4;
     static constexpr std::uint8_t IS_PRIVATE = 8;
 public:
+    /// @brief Options for public_suffix_list::get_suffix, public_suffix_list::get_suffix_info
+    /// and public_suffix_list::get_suffix_view functions
     enum class option {
-        PUBLIC_SUFFIX = 0,
-        REGISTRABLE_DOMAIN = 1,
-        ALLOW_TRAILING_DOT = 2
+        PUBLIC_SUFFIX = 0,      ///< to get public suffix
+        REGISTRABLE_DOMAIN = 1, ///< to get registrable domain
+        ALLOW_TRAILING_DOT = 2  ///< allow trailing dot in hostname input to get result as
+                                ///< defined in the URL standard; see:
+                                ///< https://url.spec.whatwg.org/#host-public-suffix
     };
 #ifdef __cpp_using_enum
     using enum option; // C++20
@@ -66,41 +103,90 @@ public:
     static constexpr auto ALLOW_TRAILING_DOT = option::ALLOW_TRAILING_DOT;
 #endif
 
+    /// @brief Return value type of the public_suffix_list::get_suffix_info function
     struct result {
+        /// @return true if public suffix or registrable domain is not null
         constexpr operator bool() const noexcept {
             return first_label_ind != static_cast<std::size_t>(-1);
         }
+        /// @return true if public suffix is in ICANN section
         constexpr bool is_icann() const noexcept {
             return (code_ & IS_ICANN) != 0;
         }
+        /// @return true if public suffix is in PRIVATE section
         constexpr bool is_private() const noexcept {
             return (code_ & IS_PRIVATE) != 0;
         }
+        /// @return true if hostname matches wildcard rule
         constexpr bool wildcard_rule() const noexcept {
             return (code_ & DIFF_MASK) == 3;
         }
+        /// First label index of public suffix or registrable domain in hostname
         std::size_t first_label_ind = static_cast<std::size_t>(-1);
+        /// First label position of public suffix or registrable domain in hostname
         std::size_t first_label_pos = static_cast<std::size_t>(-1);
         std::uint8_t code_ = 0;
     };
 
-    // Load public suffix list from file
+    /// @brief Load Public Suffix List from file
+    ///
+    /// The Public Suffix List file `public_suffix_list.dat` can be obtained from
+    /// https://publicsuffix.org/list/ or https://github.com/publicsuffix/list
+    ///
+    /// @param[in] filename the path to the Public Suffix List file
+    /// @return true if the Public Suffix List was loaded successfully
     bool load(const std::filesystem::path& filename) {
         std::ifstream finp(filename, std::ios_base::in | std::ios_base::binary);
         return finp && load(finp);
     }
+    /// @brief Load Public Suffix List from stream
+    ///
+    /// @param[in] input_stream input stream of the Public Suffix List file
+    /// @return true if the Public Suffix List was loaded successfully
     bool load(std::istream& input_stream);
 
-    // Push interface to load public suffix list 
+    // Push interface to load Public Suffix List
+
+    /// @brief Push context for public_suffix_list::push_line, public_suffix_list::push
+    /// and public_suffix_list::finalize functions
     struct push_context {
         std::string remaining{};
         std::uint8_t code_flags = 0;
     };
+
+    /// @brief Push a line of the Public Suffix List file
+    ///
+    /// There is no need to call public_suffix_list::finalize after pushing all lines.
+    ///
+    /// @param[in] ctx push context
+    /// @param[in] line text line to push
     void push_line(push_context& ctx, std::string_view line);
+
+    /// @brief Push a chunk of the Public Suffix List file
+    ///
+    /// Useful when the Public Suffix List is downloaded chunk by chunk over the network.
+    /// public_suffix_list::finalize must be called after all chunks have been processed.
+    ///
+    /// @param[in] ctx push context
+    /// @param[in] buff chunk content
     void push(push_context& ctx, std::string_view buff);
+
+    /// @brief Finalizes when all chunks are processed
+    ///
+    /// Must be called after all chunks have been processed by the
+    /// public_suffix_list::push function
+    ///
+    /// @param[in] ctx push context
+    /// @return true if the Public Suffix List was loaded successfully
     bool finalize(push_context& ctx);
 
     // Get public suffix or registrable domain
+
+    /// @brief Get public suffix or registrable domain
+    ///
+    /// @param[in] str_host hostname string
+    /// @param[in] opt options
+    /// @return public suffix or registrable domain (depends on @p opt value)
     template <class StrT, enable_if_str_arg_t<StrT> = 0>
     std::string get_suffix(StrT&& str_host, option opt = PUBLIC_SUFFIX) const {
         try {
@@ -113,18 +199,42 @@ public:
         }
     }
 
+    /// @brief Get public suffix or registrable domain information
+    ///
+    /// Returns information about the public suffix or registrable domain in a
+    /// hostname returned by url::hostname() const.
+    ///
+    /// @param[in] url the @ref url object
+    /// @param[in] opt options
+    /// @return information in the public_suffix_list::result type struct
     result get_suffix_info(const url& url, option opt = PUBLIC_SUFFIX) const {
         if (url.host_type() == HostType::Domain)
             return get_host_suffix_info(url.hostname(), opt);
         return {};
     }
 
+    /// @brief Get public suffix or registrable domain information
+    ///
+    /// Returns information about the public suffix or registrable domain of the
+    /// @p host.
+    ///
+    /// @param[in] host the url_host object
+    /// @param[in] opt options
+    /// @return information in the public_suffix_list::result type struct
     result get_suffix_info(const url_host& host, option opt = PUBLIC_SUFFIX) const {
         if (host.type() == HostType::Domain)
             return get_host_suffix_info(host.name(), opt);
         return {};
     }
 
+    /// @brief Get public suffix or registrable domain information
+    ///
+    /// Returns information about the public suffix or registrable domain of the
+    /// @p str_host string.
+    ///
+    /// @param[in] str_host hostname string
+    /// @param[in] opt options
+    /// @return information in the public_suffix_list::result type struct
     template <class StrT, enable_if_str_arg_t<StrT> = 0>
     result get_suffix_info(StrT&& str_host, option opt = PUBLIC_SUFFIX) const {
         try {
@@ -137,18 +247,40 @@ public:
         }
     }
 
+    /// @brief Get public suffix or registrable domain as string view
+    ///
+    /// Returns the public suffix or registrable domain of a hostname returned
+    /// by url::hostname() const.
+    ///
+    /// @param[in] url the @ref url object
+    /// @param[in] opt options
+    /// @return public suffix or registrable domain (depends on @p opt value)
     std::string_view get_suffix_view(const url& url, option opt = PUBLIC_SUFFIX) const {
         if (url.host_type() == HostType::Domain)
             return get_host_suffix_view(url.hostname(), opt);
         return {};
     }
 
+    /// @brief Get public suffix or registrable domain as string view
+    ///
+    /// Returns the public suffix or registrable domain of the @p host.
+    ///
+    /// @param[in] host the url_host object
+    /// @param[in] opt options
+    /// @return public suffix or registrable domain (depends on @p opt value)
     std::string_view get_suffix_view(const url_host& host, option opt = PUBLIC_SUFFIX) const {
         if (host.type() == HostType::Domain)
             return get_host_suffix_view(host.name(), opt);
         return {};
     }
 
+    /// @brief Get public suffix or registrable domain as string view
+    ///
+    /// Returns the public suffix or registrable domain of the @p str_host string.
+    ///
+    /// @param[in] str_host hostname string
+    /// @param[in] opt options
+    /// @return public suffix or registrable domain (depends on @p opt value)
     template <class StrT, enable_if_str_arg_t<StrT> = 0>
     auto get_suffix_view(StrT&& str_host, option opt = PUBLIC_SUFFIX) const
         -> std::basic_string_view<typename str_arg<str_arg_char_t<StrT>>::value_type> {
@@ -167,8 +299,11 @@ public:
         return {};
     }
 
-    bool operator==(const public_suffix_list& b) const {
-        return root_ == b.root_;
+    /// @brief Compares @c *this with @p other
+    /// @param[in] other the public_suffix_list to compare with
+    /// @return true if both lists are equal
+    bool operator==(const public_suffix_list& other) const {
+        return root_ == other.root_;
     }
 
 private:

--- a/include/upa/public_suffix_list.h
+++ b/include/upa/public_suffix_list.h
@@ -7,6 +7,7 @@
 
 #include "url.h"
 #include <cstddef>
+#include <filesystem>
 #include <fstream>
 #include <memory>
 #include <string>
@@ -19,8 +20,7 @@ namespace upa {
 class public_suffix_list {
 public:
     // Load public suffix list from file
-    template <typename CharT>
-    bool load(const CharT* filename) {
+    bool load(const std::filesystem::path& filename) {
         std::ifstream finp(filename, std::ios_base::in | std::ios_base::binary);
         return finp && load(finp);
     }

--- a/include/upa/url_host.h
+++ b/include/upa/url_host.h
@@ -106,6 +106,13 @@ public:
         return type_;
     }
 
+    /// Hostname view
+    ///
+    /// @return serialized host as string_view
+    [[nodiscard]] string_view name() const {
+        return host_str_;
+    }
+
     /// Hostname stringifier
     ///
     /// @return host serialized to string

--- a/src/public_suffix_list.cpp
+++ b/src/public_suffix_list.cpp
@@ -132,11 +132,11 @@ void public_suffix_list::push_line(push_context& ctx, std::string_view line) {
     if (line.length() >= 2) {
         if (line[0] == '/' && line[1] == '/') {
             if (line == "// ===BEGIN ICANN DOMAINS===")
-                ctx.code_flags = label_item::IS_ICANN;
+                ctx.code_flags = IS_ICANN;
             else if (line == "// ===END ICANN DOMAINS===")
                 ctx.code_flags = 0;
             else if (line == "// ===BEGIN PRIVATE DOMAINS===")
-                ctx.code_flags = label_item::IS_PRIVATE;
+                ctx.code_flags = IS_PRIVATE;
             else if (line == "// ===END PRIVATE DOMAINS===")
                 ctx.code_flags = 0;
             return;
@@ -212,7 +212,7 @@ public_suffix_list::result public_suffix_list::get_host_suffix_info(
 #endif
             if (it != pli->children->end()) {
                 if (it->second.code && (
-                    (it->second.code & label_item::DIFF_MASK) != 3 || !labels.at_end())) {
+                    (it->second.code & DIFF_MASK) != 3 || !labels.at_end())) {
                     latest_code = it->second.code;
                     latest_ind = labels.index();
                 }
@@ -228,11 +228,11 @@ public_suffix_list::result public_suffix_list::get_host_suffix_info(
         break;
     }
     if (latest_code) {
-        const int ind_diff = static_cast<int>(latest_code & label_item::DIFF_MASK) - 2 +
+        const int ind_diff = static_cast<int>(latest_code & DIFF_MASK) - 2 +
             static_cast<int>(opt & REGISTRABLE_DOMAIN);
         if (ind_diff <= 0 || static_cast<std::size_t>(ind_diff) <= latest_ind) {
             const auto ind = latest_ind - ind_diff;
-            return { ind, labels.get_pos_by_index(ind) };
+            return { ind, labels.get_pos_by_index(ind), latest_code };
         }
     }
     return {};

--- a/src/public_suffix_list.cpp
+++ b/src/public_suffix_list.cpp
@@ -1,0 +1,190 @@
+// Copyright 2024 Rimas Misevičius
+// Distributed under the BSD-style license that can be
+// found in the LICENSE file.
+//
+
+#include "upa/public_suffix_list.h"
+
+namespace upa {
+namespace {
+
+// utilities
+
+class splitter {
+public:
+    splitter(std::string_view domain);
+
+    void start();
+    bool next(std::string& label);
+    bool next(std::string_view& label);
+    std::size_t index() const {
+        return label_ind_;
+    }
+    bool at_begin() const {
+        return label_ind_ == label_pos_.size() - 1;
+    }
+    bool at_end() const {
+        return label_ind_ == 0;
+    }
+
+    std::size_t size() const {
+        return label_pos_.size();
+    }
+    std::string get_str(std::size_t ind) const {
+        return std::string{ domain_.substr(label_pos_[ind]) };
+    }
+
+private:
+    const std::string_view domain_;
+    std::vector<std::size_t> label_pos_;
+
+    std::size_t label_end_ = 0;
+    std::size_t label_ind_ = 0;
+};
+
+inline splitter::splitter(std::string_view domain)
+    : domain_{ domain }
+    , label_end_{ domain_.length() }
+{
+    label_pos_.reserve(16);
+    label_pos_.push_back(0);
+    std::size_t pos = 0;
+    while ((pos = domain_.find('.', pos)) != std::string::npos)
+        label_pos_.push_back(++pos); // skip '.' and add pos
+    label_ind_ = label_pos_.size();
+}
+
+inline void splitter::start() {
+    label_end_ = domain_.length();
+    label_ind_ = label_pos_.size();
+}
+
+inline bool splitter::next(std::string& label) {
+    if (label_ind_ != 0) {
+        const auto pos = label_pos_[--label_ind_];
+        label = domain_.substr(pos, label_end_ - pos);
+        label_end_ = pos - 1; // skip '.'
+        return true;
+    }
+    return false;
+}
+
+inline bool splitter::next(std::string_view& label) {
+    if (label_ind_ != 0) {
+        const auto pos = label_pos_[--label_ind_];
+        label = domain_.substr(pos, label_end_ - pos);
+        label_end_ = pos - 1; // skip '.'
+        return true;
+    }
+    return false;
+}
+
+constexpr void trim_dots(std::string_view& sv) {
+    const auto* first = sv.data();
+    const auto* last = first + sv.length();
+    while (first != last && *first == '.') ++first;
+    while (first != last && *(last - 1) == '.') --last;
+    sv = std::string_view{ first, static_cast<std::size_t>(last - first) };
+}
+
+} // namespace
+
+// class public_suffix_list
+
+bool public_suffix_list::load(std::istream& input) {
+    static constexpr auto insert = [](label_item& root, std::string domain, std::uint8_t code) {
+
+        // TODO: ONLY Punycode
+        upa::url_host host(domain);
+        domain = host.to_string();
+
+        splitter labels(domain);
+        label_item* pli = &root;
+        std::string label;
+        while (labels.next(label)) {
+            if (!pli->children)
+                pli->children = std::make_unique<label_item::map_type>();
+            if (labels.at_end())
+                (*pli->children)[label].code = code;
+            else
+                pli->children->emplace(label, label_item{});
+            pli = &(*pli->children)[label];
+        }
+    };
+
+    std::uint8_t code_flags = 0;
+
+    std::string line;
+    while (std::getline(input, line)) {
+        if (line.empty())
+            continue;
+        if (line.length() >= 2) {
+            if (line[0] == '/' && line[1] == '/') {
+                if (line == "// ===BEGIN ICANN DOMAINS===")
+                    code_flags = label_item::IS_ICANN;
+                else if (line == "// ===END ICANN DOMAINS===")
+                    code_flags = 0;
+                else if (line == "// ===BEGIN PRIVATE DOMAINS===")
+                    code_flags = label_item::IS_PRIVATE;
+                else if (line == "// ===END PRIVATE DOMAINS===")
+                    code_flags = 0;
+                continue;
+            }
+            if (line[0] == '*' && line[1] == '.') {
+                insert(root_, line.substr(2), 3 | code_flags);
+                continue;
+            }
+        }
+        if (line[0] == '!')
+            insert(root_, line.substr(1), 1 | code_flags);
+        else
+            insert(root_, line, 2 | code_flags);
+    }
+    return true;
+}
+
+std::string public_suffix_list::get_host_suffix(std::string_view hostname, bool reg_domain) const {
+    // Definitions. Empty labels are not permitted, meaning that leading
+    // and trailing dots are ignored.
+    trim_dots(hostname);
+
+    // Split to labels
+    splitter labels(hostname);
+
+    const label_item* pli = &root_;
+    std::uint8_t latest_code = 0;
+    std::size_t latest_ind = 0;
+    std::string_view label;
+    while (labels.next(label)) {
+        if (pli->children) {
+#ifdef __cpp_lib_generic_unordered_lookup
+            auto it = pli->children->find(label);
+#else
+            auto it = pli->children->find(std::string{ label });
+#endif
+            if (it != pli->children->end()) {
+                if (it->second.code && (
+                    (it->second.code & label_item::DIFF_MASK) != 3 || !labels.at_end())) {
+                    latest_code = it->second.code;
+                    latest_ind = labels.index();
+                }
+                pli = &it->second;
+                continue;
+            }
+        }
+        if (labels.at_begin()) {
+            // Unlisted TLD: If no rules match, the prevailing rule is "*"
+            latest_code = 2;
+            latest_ind = labels.index();
+        }
+        break;
+    }
+    if (latest_code) {
+        const int ind_diff = static_cast<int>(latest_code & label_item::DIFF_MASK) - 2 + static_cast<int>(reg_domain);
+        if (ind_diff <= 0 || static_cast<std::size_t>(ind_diff) <= latest_ind)
+            return labels.get_str(latest_ind - ind_diff);
+    }
+    return {};
+}
+
+} // namespace upa

--- a/test/bench-public_suffix_list.cpp
+++ b/test/bench-public_suffix_list.cpp
@@ -1,0 +1,58 @@
+// Copyright 2024 Rimas Misevičius
+// Distributed under the BSD-style license that can be
+// found in the LICENSE file.
+//
+#include "upa/public_suffix_list.h"
+
+#define ANKERL_NANOBENCH_IMPLEMENT
+#include "ankerl/nanobench.h"
+
+#include <cstdint>
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <vector>
+
+int bench_psl_list(const char* filename) {
+    constexpr uint64_t min_iters = 128;
+    std::vector<std::string> domain_list;
+
+    std::ifstream finp(filename, std::ios_base::in | std::ios_base::binary);
+    if (!finp) {
+        std::cerr << "Can not open: " << filename << '\n';
+        return 1;
+    }
+
+    std::string line;
+    while (std::getline(finp, line)) {
+        if (line.empty())
+            continue;
+        if (line.length() >= 2 && line[0] == '/' && line[1] == '/')
+            continue;
+
+        const auto isep = line.find(' ');
+        domain_list.push_back(line.substr(0, isep));
+    }
+
+    const char* filename_psl = "psl/public_suffix_list.dat";
+
+    upa::public_suffix_list ps_list;
+    if (!ps_list.load(filename_psl)) {
+        std::cerr << "Can not open: " << filename_psl << '\n';
+        return 1;
+    }
+
+    ankerl::nanobench::Bench().minEpochIterations(min_iters).run("public_suffix_list",
+        [&] {
+            for (const auto& str_domain : domain_list) {
+                std::string reg_domain = ps_list.get_suffix(str_domain, true);
+                ankerl::nanobench::doNotOptimizeAway(reg_domain);
+            }
+        });
+
+    return 0;
+}
+
+int main() {
+    return bench_psl_list("psl/tests.txt");
+}

--- a/test/bench-public_suffix_list.cpp
+++ b/test/bench-public_suffix_list.cpp
@@ -9,11 +9,12 @@
 
 #include <cstdint>
 #include <iostream>
+#include <filesystem>
 #include <fstream>
 #include <string>
 #include <vector>
 
-int bench_psl_list(const char* filename) {
+int bench_psl_list(const std::filesystem::path& filename) {
     constexpr uint64_t min_iters = 128;
     std::vector<std::string> domain_list;
 
@@ -34,7 +35,7 @@ int bench_psl_list(const char* filename) {
         domain_list.push_back(line.substr(0, isep));
     }
 
-    const char* filename_psl = "psl/public_suffix_list.dat";
+    const std::filesystem::path filename_psl{ "psl/public_suffix_list.dat" };
 
     upa::public_suffix_list ps_list;
     if (!ps_list.load(filename_psl)) {

--- a/test/bench-public_suffix_list.cpp
+++ b/test/bench-public_suffix_list.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Rimas Misevičius
+// Copyright 2024-2025 Rimas Misevičius
 // Distributed under the BSD-style license that can be
 // found in the LICENSE file.
 //
@@ -46,7 +46,8 @@ int bench_psl_list(const std::filesystem::path& filename) {
     ankerl::nanobench::Bench().minEpochIterations(min_iters).run("public_suffix_list",
         [&] {
             for (const auto& str_domain : domain_list) {
-                std::string reg_domain = ps_list.get_suffix(str_domain, true);
+                std::string reg_domain = ps_list.get_suffix(str_domain,
+                    upa::public_suffix_list::REGISTRABLE_DOMAIN);
                 ankerl::nanobench::doNotOptimizeAway(reg_domain);
             }
         });

--- a/test/bench-public_suffix_list.cpp
+++ b/test/bench-public_suffix_list.cpp
@@ -14,10 +14,11 @@
 #include <string>
 #include <vector>
 
-int bench_psl_list(const std::filesystem::path& filename) {
+int bench_psl_list(const std::filesystem::path& path, const std::filesystem::path& filename) {
     constexpr uint64_t min_iters = 128;
     std::vector<std::string> domain_list;
 
+    std::cout << "Load domains from: " << filename << '\n';
     std::ifstream finp(filename, std::ios_base::in | std::ios_base::binary);
     if (!finp) {
         std::cerr << "Can not open: " << filename << '\n';
@@ -35,7 +36,7 @@ int bench_psl_list(const std::filesystem::path& filename) {
         domain_list.push_back(line.substr(0, isep));
     }
 
-    const std::filesystem::path filename_psl{ "psl/public_suffix_list.dat" };
+    const std::filesystem::path filename_psl{ path / "public_suffix_list.dat" };
 
     upa::public_suffix_list ps_list;
     if (!ps_list.load(filename_psl)) {
@@ -55,6 +56,20 @@ int bench_psl_list(const std::filesystem::path& filename) {
     return 0;
 }
 
-int main() {
-    return bench_psl_list("psl/tests.txt");
+int main(int argc, const char* argv[])
+{
+    if (argc < 2 || argc > 3) {
+        std::cerr <<
+            "Usage: bench-public_suffix_list"
+            " <directory of public_suffix_list.dat>"
+            " [<file containing domains>]\n";
+        return 1;
+    }
+
+    const std::filesystem::path path = argv[1];
+    const std::filesystem::path filename = argc > 2
+        ? std::filesystem::path{ argv[2] }
+        : path / "tests.txt";
+
+    return bench_psl_list(path, filename);
 }

--- a/test/data/my-psl-tests.txt
+++ b/test/data/my-psl-tests.txt
@@ -1,0 +1,6 @@
+// Unicode FULL STOP code points:
+// U+002E, U+3002, U+FF0E, U+FF61
+a.b.example.com example.com
+a。b。example。com example。com
+a．b．example．com example．com
+a｡b｡example｡com example｡com

--- a/test/data/whatwg-psl-tests.txt
+++ b/test/data/whatwg-psl-tests.txt
@@ -1,0 +1,14 @@
+// Tests from example at https://url.spec.whatwg.org/#host-miscellaneous
+// Format: input SP expected suffix SP expected domain
+com com null
+example.com com example.com
+www.example.com com example.com
+sub.www.example.com com example.com
+EXAMPLE.COM com example.com
+example.com. com. example.com.
+github.io github.io null
+whatwg.github.io github.io whatwg.github.io
+إختبار xn--kgbechtv null
+example.إختبار xn--kgbechtv example.xn--kgbechtv
+sub.example.إختبار xn--kgbechtv example.xn--kgbechtv
+[2001:0db8:85a3:0000:0000:8a2e:0370:7334] null null

--- a/test/download-tests.bat
+++ b/test/download-tests.bat
@@ -12,3 +12,10 @@ set HASH=6fa3fe8a929be45422cd46a8961e647e13d0cab8
 for %%f in (setters_tests.json toascii.json urltestdata.json urltestdata-javascript-only.json percent-encoding.json IdnaTestV2.json) do (
   curl -fsS -o %p%\wpt\%%f https://raw.githubusercontent.com/web-platform-tests/wpt/%HASH%/url/resources/%%f
 )
+
+REM Commit hash of the Public Suffix List (PSL)
+REM https://github.com/publicsuffix/list
+set PSL_HASH=f34b2f1a960238cf765d2e70ca8459ea2de51ec7
+
+curl -fsS -o %p%\psl\public_suffix_list.dat https://raw.githubusercontent.com/publicsuffix/list/%PSL_HASH%/public_suffix_list.dat
+curl -fsS -o %p%\psl\tests.txt https://raw.githubusercontent.com/publicsuffix/list/%PSL_HASH%/tests/tests.txt

--- a/test/download-tests.sh
+++ b/test/download-tests.sh
@@ -14,3 +14,10 @@ for f in setters_tests.json toascii.json urltestdata.json urltestdata-javascript
 do
   curl -fsS -o $p/wpt/$f https://raw.githubusercontent.com/web-platform-tests/wpt/${HASH}/url/resources/$f
 done
+
+# Commit hash of the Public Suffix List (PSL)
+# https://github.com/publicsuffix/list
+PSL_HASH=f34b2f1a960238cf765d2e70ca8459ea2de51ec7
+
+curl -fsS -o $p/psl/public_suffix_list.dat https://raw.githubusercontent.com/publicsuffix/list/${PSL_HASH}/public_suffix_list.dat
+curl -fsS -o $p/psl/tests.txt https://raw.githubusercontent.com/publicsuffix/list/${PSL_HASH}/tests/tests.txt

--- a/test/test-public_suffix_list.cpp
+++ b/test/test-public_suffix_list.cpp
@@ -1,0 +1,62 @@
+// Copyright 2024 Rimas Misevičius
+// Distributed under the BSD-style license that can be
+// found in the LICENSE file.
+//
+#include "upa/public_suffix_list.h"
+
+#include <algorithm>
+#include <iostream>
+#include <fstream>
+#include <string>
+
+int test_public_suffix_list(const upa::public_suffix_list& ps_list, const char* filename) {
+    // Open tests file
+    std::ifstream finp(filename, std::ios_base::in | std::ios_base::binary);
+    if (!finp) {
+        std::cerr << "Can not open: " << filename << '\n';
+        return 1;
+    }
+
+    int res = 0;
+
+    std::string line;
+    while (std::getline(finp, line)) {
+        if (line.empty())
+            continue;
+        if (line.length() >= 2 && line[0] == '/' && line[1] == '/')
+            continue;
+
+        const auto isep = line.find(' ');
+        if (isep == std::string::npos) {
+            std::cerr << "INVALID LINE: " << line << '\n';
+            continue;
+        }
+        const std::string domain = line.substr(0, isep);
+        const std::string expected = line.substr(isep + 1); // skip ' '
+
+        std::string output = ps_list.get_suffix(domain, true);
+        if (output.empty())
+            output = "null";
+
+        if (output == expected) {
+            std::cout << "OK: " << line << '\n';
+        } else {
+            std::cout << "FAIL: " << line << '\n';
+            std::cout << "  " << output << " != " << expected << '\n';
+            res = 1;
+        }
+    }
+    return res;
+}
+
+int main() {
+    const char* filename_psl = "psl/public_suffix_list.dat";
+
+    upa::public_suffix_list ps_list;
+    if (!ps_list.load(filename_psl)) {
+        std::cerr << "Can not open: " << filename_psl << '\n';
+        return 1;
+    }
+
+    return test_public_suffix_list(ps_list, "psl/tests.txt");
+}

--- a/test/test-public_suffix_list.cpp
+++ b/test/test-public_suffix_list.cpp
@@ -133,6 +133,69 @@ TEST_SUITE("public_suffix_list::get_suffix") {
     }
 }
 
+TEST_SUITE("public_suffix_list::get_suffix_info") {
+    TEST_CASE("url with registrable domain") {
+        upa::url input{ "http://EXAMPLE.COM" };
+        const auto output = ps_list.get_suffix_info(input,
+            upa::public_suffix_list::REGISTRABLE_DOMAIN);
+        INFO("input (url): ", input.href());
+        REQUIRE(static_cast<bool>(output));
+        CHECK(output.first_label_pos == 0);
+        CHECK(output.first_label_ind == 0);
+        CHECK(output.is_icann());
+        CHECK_FALSE(output.is_private());
+        CHECK_FALSE(output.wildcard_rule());
+    }
+    TEST_CASE("url with non-registrable domain") {
+        upa::url input{ "http://com" };
+        const auto output = ps_list.get_suffix_info(input,
+            upa::public_suffix_list::REGISTRABLE_DOMAIN);
+        INFO("input (url): ", input.href());
+        REQUIRE_FALSE(static_cast<bool>(output));
+    }
+
+    TEST_CASE("url_host with registrable domain") {
+        upa::url_host input{ "upa-url.github.io" };
+        const auto output = ps_list.get_suffix_info(input,
+            upa::public_suffix_list::REGISTRABLE_DOMAIN);
+        INFO("input (url_host): ", input.name());
+        REQUIRE(static_cast<bool>(output));
+        CHECK(output.first_label_pos == 0);
+        CHECK(output.first_label_ind == 0);
+        CHECK_FALSE(output.is_icann());
+        CHECK(output.is_private());
+        CHECK_FALSE(output.wildcard_rule());
+    }
+    TEST_CASE("url_host with non-registrable domain") {
+        upa::url_host input{ "github.io" };
+        const auto output = ps_list.get_suffix_info(input,
+            upa::public_suffix_list::REGISTRABLE_DOMAIN);
+        INFO("input (url_host): ", input.name());
+        REQUIRE_FALSE(static_cast<bool>(output));
+    }
+
+    TEST_CASE("registrable domain") {
+        std::string input = "a.b.c.hosted.app";
+        const auto output = ps_list.get_suffix_info(input,
+            upa::public_suffix_list::REGISTRABLE_DOMAIN);
+        INFO("input: ", input);
+        // Rule: *.hosted.app => registrable domain: b.c.hosted.app
+        REQUIRE(static_cast<bool>(output));
+        CHECK(output.first_label_pos == 2);
+        CHECK(output.first_label_ind == 1);
+        CHECK_FALSE(output.is_icann());
+        CHECK(output.is_private());
+        CHECK(output.wildcard_rule());
+    }
+    TEST_CASE("invalid domain") {
+        std::string input = "<>.com";
+        const auto output = ps_list.get_suffix_info(input,
+            upa::public_suffix_list::REGISTRABLE_DOMAIN);
+        INFO("input: ", input);
+        REQUIRE_FALSE(static_cast<bool>(output));
+    }
+}
+
 TEST_SUITE("public_suffix_list::get_suffix_view") {
     TEST_CASE("url with registrable domain") {
         upa::url input{ "http://EXAMPLE.ORG" };

--- a/test/test-public_suffix_list.cpp
+++ b/test/test-public_suffix_list.cpp
@@ -213,6 +213,33 @@ TEST_SUITE("public_suffix_list::get_suffix_view") {
     }
 }
 
+TEST_SUITE("public_suffix_list push interface") {
+    TEST_CASE("public_suffix_list::push") {
+        const std::filesystem::path filename{ "psl/public_suffix_list.dat" };
+        std::ifstream finp(filename, std::ios_base::in | std::ios_base::binary);
+        REQUIRE(finp);
+
+        upa::public_suffix_list psl;
+        upa::public_suffix_list::push_context ctx;
+        char buffer[64];
+        while (finp) {
+            finp.read(buffer, sizeof(buffer));
+            psl.push(ctx, { buffer, static_cast<std::size_t>(finp.gcount()) });
+        }
+        REQUIRE(psl.finalize(ctx));
+
+        CHECK(psl == ps_list);
+    }
+    TEST_CASE("public_suffix_list::finalize") {
+        upa::public_suffix_list psl;
+        upa::public_suffix_list::push_context ctx;
+        // Push text without EOL
+        psl.push(ctx, "github.io");
+        CHECK(psl.finalize(ctx));
+        CHECK(psl.get_suffix("upa-url.github.io") == "github.io");
+    }
+}
+
 int test_public_suffix_list_functions(int argc, char** argv) {
     std::cout << "========== Test public_suffix_list functions ==========\n";
 

--- a/test/test-public_suffix_list.cpp
+++ b/test/test-public_suffix_list.cpp
@@ -6,10 +6,11 @@
 
 #include <algorithm>
 #include <iostream>
+#include <filesystem>
 #include <fstream>
 #include <string>
 
-int test_public_suffix_list(const upa::public_suffix_list& ps_list, const char* filename) {
+int test_public_suffix_list(const upa::public_suffix_list& ps_list, const std::filesystem::path& filename) {
     // Open tests file
     std::ifstream finp(filename, std::ios_base::in | std::ios_base::binary);
     if (!finp) {
@@ -50,7 +51,7 @@ int test_public_suffix_list(const upa::public_suffix_list& ps_list, const char* 
 }
 
 int main() {
-    const char* filename_psl = "psl/public_suffix_list.dat";
+    const std::filesystem::path filename_psl{ "psl/public_suffix_list.dat" };
 
     upa::public_suffix_list ps_list;
     if (!ps_list.load(filename_psl)) {


### PR DESCRIPTION
Implements the Public Suffix List algorithm defined here: https://github.com/publicsuffix/list/wiki/Format#formal-algorithm

It also implements the URL standard [public suffix](https://url.spec.whatwg.org/#host-public-suffix) and [registrable domain](https://url.spec.whatwg.org/#host-registrable-domain) algorithms.

The Public Suffix List file `public_suffix_list.dat` can be obtained from https://publicsuffix.org/list/ or https://github.com/publicsuffix/list

Example:
```c++
upa::public_suffix_list psl;
if (psl.load("public_suffix_list.dat")) {
    auto input = "upa-url.github.io.";
    auto suffix = psl.get_suffix_view(input,
        upa::public_suffix_list::ALLOW_TRAILING_DOT);
    std::cout << "Public suffix of " << input << " is " << suffix << '\n';
}
```