### PR TITLE
Move `get_scheme_info` from `url` class to `detail` namespace

### DIFF
--- a/src/url.cpp
+++ b/src/url.cpp
@@ -8,6 +8,49 @@
 namespace upa {
 namespace detail {
 
+// Scheme info
+
+namespace {
+
+// MUST be sorted by length
+const scheme_info kSchemes[] = {
+    // scheme,         port, is_special, is_file, is_http, is_ws
+    { { "ws", 2 },       80,          1,       0,       0,     1 },
+    { { "wss", 3 },     443,          1,       0,       0,     1 },
+    { { "ftp", 3 },      21,          1,       0,       0,     0 },
+    { { "http", 4 },     80,          1,       0,       1,     0 },
+    { { "file", 4 },     -1,          1,       1,       0,     0 },
+    { { "https", 5 },   443,          1,       0,       1,     0 },
+};
+
+const std::size_t max_scheme_length = 5; // "https"
+
+// scheme length to url::kSchemes index
+const uint8_t kLengthToSchemesInd[] = {
+    0,  // 0
+    0,  // 1
+    0,  // 2
+    1,  // 3
+    3,  // 4
+    5,  // 5
+    6,  // the end
+};
+
+} // namespace
+
+const scheme_info* get_scheme_info(const string_view src) {
+    const std::size_t len = src.length();
+    if (len <= max_scheme_length) {
+        const int end = kLengthToSchemesInd[len + 1];
+        for (int ind = kLengthToSchemesInd[len]; ind < end; ++ind) {
+            // The src and kSchemes[ind].scheme lengths are the same, so compare data only
+            if (string_view::traits_type::compare(src.data(), kSchemes[ind].scheme.data(), len) == 0)
+                return &kSchemes[ind];
+        }
+    }
+    return nullptr;
+}
+
 // url_error exception what() values
 
 const char* const kURLParseError = "URL parse error";
@@ -58,43 +101,6 @@ const unsigned url::kPartFlagMask[url::PART_COUNT] = {
     QUERY_FLAG,
     FRAGMENT_FLAG
 };
-
-// MUST be sorted by length
-const url::scheme_info url::kSchemes[] = {
-    // scheme,         port, is_special, is_file, is_http, is_ws
-    { { "ws", 2 },       80,          1,       0,       0,     1 },
-    { { "wss", 3 },     443,          1,       0,       0,     1 },
-    { { "ftp", 3 },      21,          1,       0,       0,     0 },
-    { { "http", 4 },     80,          1,       0,       1,     0 },
-    { { "file", 4 },     -1,          1,       1,       0,     0 },
-    { { "https", 5 },   443,          1,       0,       1,     0 },
-};
-
-static const std::size_t max_scheme_length = 5; // "https"
-
-// scheme length to url::kSchemes index
-static const uint8_t kLengthToSchemesInd[] = {
-    0,  // 0
-    0,  // 1
-    0,  // 2
-    1,  // 3
-    3,  // 4
-    5,  // 5
-    6,  // the end
-};
-
-const url::scheme_info* url::get_scheme_info(const string_view src) {
-    const std::size_t len = src.length();
-    if (len <= max_scheme_length) {
-        const int end = kLengthToSchemesInd[len + 1];
-        for (int ind = kLengthToSchemesInd[len]; ind < end; ++ind) {
-            // The src and kSchemes[ind].scheme lengths are the same, so compare data only
-            if (string_view::traits_type::compare(src.data(), kSchemes[ind].scheme.data(), len) == 0)
-                return &kSchemes[ind];
-        }
-    }
-    return nullptr;
-}
 
 
 } // namespace upa


### PR DESCRIPTION
This allows it to be used not only from the `url` class.