### PR TITLE
Add U+005E (^) to the path percent-encode set

### DIFF
--- a/include/upa/url_percent_encode.h
+++ b/include/upa/url_percent_encode.h
@@ -135,7 +135,7 @@ inline constexpr code_point_set special_query_no_encode_set{ [](code_point_set& 
 // https://url.spec.whatwg.org/#path-percent-encode-set
 inline constexpr code_point_set path_no_encode_set{ [](code_point_set& self) constexpr {
     self.copy(query_no_encode_set);
-    self.exclude({ 0x3F, 0x60, 0x7B, 0x7D });
+    self.exclude({ 0x3F, 0x5E, 0x60, 0x7B, 0x7D });
     } };
 
 // path percent-encode set with '%' (0x25)
@@ -156,7 +156,7 @@ inline constexpr code_point_set posix_path_no_encode_set{ [](code_point_set& sel
 // https://url.spec.whatwg.org/#userinfo-percent-encode-set
 inline constexpr code_point_set userinfo_no_encode_set{ [](code_point_set& self) constexpr {
     self.copy(path_no_encode_set);
-    self.exclude({ 0x2F, 0x3A, 0x3B, 0x3D, 0x40, 0x5B, 0x5C, 0x5D, 0x5E, 0x7C });
+    self.exclude({ 0x2F, 0x3A, 0x3B, 0x3D, 0x40, 0x5B, 0x5C, 0x5D, 0x7C });
     } };
 
 // component percent-encode set

--- a/test/download-tests.bat
+++ b/test/download-tests.bat
@@ -7,7 +7,7 @@ REM Commit hash of web-platform-tests (wpt)
 REM
 REM Run tools\update-wpt.py to update to the latest commit hash from
 REM https://github.com/web-platform-tests/wpt/tree/master/url
-set HASH=7c9c41aedbcd49bf96fb9e35a133293b3977b83d
+set HASH=d2c39364360cfa39ce900f643f55ca6ef7b33093
 
 for %%f in (setters_tests.json toascii.json urltestdata.json urltestdata-javascript-only.json percent-encoding.json IdnaTestV2.json IdnaTestV2-removed.json) do (
   curl -fsS -o %p%\wpt\%%f https://raw.githubusercontent.com/web-platform-tests/wpt/%HASH%/url/resources/%%f

--- a/test/download-tests.sh
+++ b/test/download-tests.sh
@@ -8,7 +8,7 @@ p="$(dirname "$0")"
 #
 # Run tools/update-wpt.py to update to the latest commit hash from
 # https://github.com/web-platform-tests/wpt/tree/master/url
-HASH=7c9c41aedbcd49bf96fb9e35a133293b3977b83d
+HASH=d2c39364360cfa39ce900f643f55ca6ef7b33093
 
 for f in setters_tests.json toascii.json urltestdata.json urltestdata-javascript-only.json percent-encoding.json IdnaTestV2.json IdnaTestV2-removed.json
 do


### PR DESCRIPTION
Follows: https://github.com/whatwg/url/commit/9bc33c39d4a6cd6a936ea7620b5a69f606ec0d4c

Tests: https://github.com/web-platform-tests/wpt/commit/d2c39364360cfa39ce900f643f55ca6ef7b33093