### PR TITLE
Update WPT

### DIFF
--- a/test/download-tests.bat
+++ b/test/download-tests.bat
@@ -7,7 +7,7 @@ REM Commit hash of web-platform-tests (wpt)
 REM
 REM Run tools\update-wpt.py to update to the latest commit hash from
 REM https://github.com/web-platform-tests/wpt/tree/master/url
-set HASH=048018b5af85f8d47b8a704b48cf6f9c0a461876
+set HASH=072413fba2fef3c16877673af78215174ca8f7c2
 
 for %%f in (setters_tests.json toascii.json urltestdata.json urltestdata-javascript-only.json percent-encoding.json IdnaTestV2.json IdnaTestV2-removed.json) do (
   curl -fsS -o %p%\wpt\%%f https://raw.githubusercontent.com/web-platform-tests/wpt/%HASH%/url/resources/%%f

--- a/test/download-tests.sh
+++ b/test/download-tests.sh
@@ -8,7 +8,7 @@ p="$(dirname "$0")"
 #
 # Run tools/update-wpt.py to update to the latest commit hash from
 # https://github.com/web-platform-tests/wpt/tree/master/url
-HASH=048018b5af85f8d47b8a704b48cf6f9c0a461876
+HASH=072413fba2fef3c16877673af78215174ca8f7c2
 
 for f in setters_tests.json toascii.json urltestdata.json urltestdata-javascript-only.json percent-encoding.json IdnaTestV2.json IdnaTestV2-removed.json
 do

--- a/test/test-url.cpp
+++ b/test/test-url.cpp
@@ -244,6 +244,7 @@ TEST_CASE("url::can_parse") {
 
         CHECK(upa::url::can_parse("aaa:b", nullptr));
         CHECK_FALSE(upa::url::can_parse("undefined", "aaa:b"));
+        CHECK_FALSE(upa::url::can_parse("undefined", "https://test:test/"));
 
         CHECK(upa::url::can_parse("aaa:/b", nullptr));
         CHECK(upa::url::can_parse("undefined", "aaa:/b"));

--- a/test/wpt-url.cpp
+++ b/test/wpt-url.cpp
@@ -81,8 +81,12 @@ public:
     string_or_null(const picojson::value& json_value)
         : has_val_{ !json_value.is<picojson::null>() }
     {
-        if (has_val_)
-            val_ = json_value.get<std::string>();
+        if (has_val_) {
+            if (json_value.is<std::string>())
+                val_ = json_value.get<std::string>();
+            else // boolean
+                val_ = json_value.get<bool>() ? "true" : "false";
+        }
     }
     ~string_or_null() = default;
 
@@ -215,6 +219,44 @@ void test_parser(DataDrivenTest& ddt, const parsed_obj_with_failure& obj)
     });
 }
 
+// Test upa::idna::domain_to_ascii
+// This function is used in test_host_parser and test_idna_v2
+void test_domain_to_ascii(DataDrivenTest& ddt, const parsed_obj& obj)
+{
+    // "input" and "output" are mandatory
+    const auto& input = obj.at("input");
+    const auto& output = obj.at("output");
+
+    const bool is_input_ascii = std::all_of(input->begin(), input->end(),
+        [](char c) { return static_cast<unsigned char>(c) < 0x80; });
+
+    std::string str_case("domain_to_ascii(\"" + *input + "\")");
+    if (obj.has("comment"))
+        str_case += " " + *obj.at("comment");
+
+    ddt.test_case(str_case, [&](DataDrivenTest::TestCase& tc) {
+        std::string domain;
+        bool parse_success = upa::idna::domain_to_ascii(domain, input->data(), input->data() + input->size());
+
+        // check if parse must succeed
+        tc.assert_equal(output.has_value(), parse_success, "domain_to_ascii success");
+        if (parse_success && output) {
+            tc.assert_equal(*output, domain, "domain_to_ascii output");
+        }
+
+        if (is_input_ascii) {
+            domain.clear();
+            parse_success = upa::idna::domain_to_ascii(domain, input->data(), input->data() + input->size(), false, is_input_ascii);
+
+            // check if parse must succeed
+            tc.assert_equal(output.has_value(), parse_success, "ASCII domain_to_ascii success");
+            if (parse_success && output) {
+                tc.assert_equal(*output, domain, "ASCII domain_to_ascii output");
+            }
+        }
+    });
+}
+
 //
 // https://github.com/web-platform-tests/wpt/blob/master/url/toascii.window.js
 //
@@ -233,6 +275,7 @@ void test_host_parser(DataDrivenTest& ddt, const parsed_obj& obj)
     // "input" and "output" are mandatory
     const auto& input = obj.at("input");
     const auto& output = obj.at("output");
+    const bool urlStandardOnly = obj.has("urlStandardOnly") && *obj.at("urlStandardOnly") == "true";
 
     std::string str_case("Parse URL with host: \"" + *input + "\"");
 
@@ -279,6 +322,11 @@ void test_host_parser(DataDrivenTest& ddt, const parsed_obj& obj)
             tc.assert_equal("x", url.hostname(), "hostname");
         }
     });
+
+    // Test upa::idna::domain_to_ascii
+
+    if (!urlStandardOnly)
+        test_domain_to_ascii(ddt, obj);
 }
 
 //
@@ -331,34 +379,7 @@ void test_idna_v2(DataDrivenTest& ddt, const parsed_obj& obj)
 
     // Test upa::idna::domain_to_ascii
 
-    const bool is_input_ascii = std::all_of(input->begin(), input->end(),
-        [](char c) { return static_cast<unsigned char>(c) < 0x80; });
-
-    str_case = "domain_to_ascii(\"" + *input + "\")";
-    if (obj.has("comment"))
-        str_case += " " + *obj.at("comment");
-
-    ddt.test_case(str_case, [&](DataDrivenTest::TestCase& tc) {
-        std::string domain;
-        bool parse_success = upa::idna::domain_to_ascii(domain, input->data(), input->data() + input->size());
-
-        // check if parse must succeed
-        tc.assert_equal(output.has_value(), parse_success, "domain_to_ascii success");
-        if (parse_success && output) {
-            tc.assert_equal(*output, domain, "domain_to_ascii output");
-        }
-
-        if (is_input_ascii) {
-            domain.clear();
-            parse_success = upa::idna::domain_to_ascii(domain, input->data(), input->data() + input->size(), false, is_input_ascii);
-
-            // check if parse must succeed
-            tc.assert_equal(output.has_value(), parse_success, "ASCII domain_to_ascii success");
-            if (parse_success && output) {
-                tc.assert_equal(*output, domain, "ASCII domain_to_ascii output");
-            }
-        }
-    });
+    test_domain_to_ascii(ddt, obj);
 }
 
 // URL setter test

--- a/test/wpt-url_search_params.cpp
+++ b/test/wpt-url_search_params.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2023 Rimas Misevičius
+// Copyright 2016-2025 Rimas Misevičius
 // Distributed under the BSD-style license that can be
 // found in the LICENSE file.
 //


### PR DESCRIPTION
* Update WPT: Tag URL Standard-only ToASCII tests (https://github.com/web-platform-tests/wpt/commit/cf2401eb2526e5f35b2a5b7a458faadc154dc5d3) and test `upa::idna::domain_to_ascii` with `toascii.json` tests.
* Update WPT: Add test coverage for bad base URLs to URL.canParse() (https://github.com/web-platform-tests/wpt/commit/6d8409b305d7679fd9fef4ad13c8a3b03b5f9a3e)