### PR TITLE
Use Public Suffix List (PSL) in Upa URL demo

### DIFF
--- a/examples/url-demo/.gitignore
+++ b/examples/url-demo/.gitignore
@@ -1,2 +1,4 @@
 # Ignore compiler output
 /www/url-api.*
+# Public Suffix List file
+/www/public_suffix_list.dat

--- a/examples/url-demo/README.md
+++ b/examples/url-demo/README.md
@@ -4,5 +4,6 @@ The Upa URL demo is available online at https://upa-url.github.io/demo/
 
 How to prepare for the Web:
 1. Install and activate Emscripten, more information: https://emscripten.org/docs/getting_started/downloads.html
-2. Build `url-api.cpp` with `build-url-api.sh` (`build-url-api.bat` on Windows) script. Output files `url-api.js` and `url-api.wasm` will be written to the `www` directory..
-3. Publish contents of `www` directory to web server.
+2. Build `url-api.cpp` with `build-url-api.sh` (`build-url-api.bat` on Windows) script. Output files `url-api.js` and `url-api.wasm` will be written to the `www` directory.
+3. Optionally, the Public Suffix List file `public_suffix_list.dat` can be downloaded from https://publicsuffix.org/list/ into the `www` directory. Then the [registrable domain](https://url.spec.whatwg.org/#host-registrable-domain) of the parsed URL host will be displayed.
+4. Publish contents of `www` directory to web server.

--- a/examples/url-demo/build-url-api.bat
+++ b/examples/url-demo/build-url-api.bat
@@ -9,12 +9,14 @@ cd %p%../..
 
 REM Compile
 call emcc examples/url-demo/url-api.cpp ^
+  src/public_suffix_list.cpp ^
   src/url.cpp ^
   src/url_ip.cpp ^
   src/url_percent_encode.cpp ^
   src/url_search_params.cpp ^
   src/url_utf.cpp ^
   src/idna.cpp ^
+  -fwasm-exceptions ^
   -Iinclude -std=c++17 -O3 ^
   -lembind ^
   -o examples/url-demo/www/url-api.js

--- a/examples/url-demo/build-url-api.sh
+++ b/examples/url-demo/build-url-api.sh
@@ -9,12 +9,14 @@ cd $p/../..
 
 # Compile
 emcc examples/url-demo/url-api.cpp \
+  src/public_suffix_list.cpp \
   src/url.cpp \
   src/url_ip.cpp \
   src/url_percent_encode.cpp \
   src/url_search_params.cpp \
   src/url_utf.cpp \
   src/idna.cpp \
+  -fwasm-exceptions \
   -Iinclude -std=c++17 -O3 \
   -lembind \
   -o examples/url-demo/www/url-api.js

--- a/examples/url-demo/url-api.cpp
+++ b/examples/url-demo/url-api.cpp
@@ -107,6 +107,10 @@ public:
     bool base_valid() const {
         return m_base_valid;
     }
+
+    const upa::url& url() const {
+        return m_url;
+    }
 private:
     upa::url m_url;
     bool m_base_valid;
@@ -133,6 +137,16 @@ public:
         return m_psl.get_suffix(str_host,
             upa::public_suffix_list::ALLOW_TRAILING_DOT |
             upa::public_suffix_list::REGISTRABLE_DOMAIN);
+    }
+
+    std::string url_public_suffix(const URL& url) const {
+        return std::string{ m_psl.get_suffix_view(url.url(),
+            upa::public_suffix_list::ALLOW_TRAILING_DOT) };
+    }
+    std::string url_registrable_domain(const URL& url) const {
+        return std::string{ m_psl.get_suffix_view(url.url(),
+            upa::public_suffix_list::ALLOW_TRAILING_DOT |
+            upa::public_suffix_list::REGISTRABLE_DOMAIN) };
     }
 private:
     upa::public_suffix_list m_psl;
@@ -165,5 +179,7 @@ EMSCRIPTEN_BINDINGS(url_api) {
         .function("push", &PSL::push)
         .function("finalize", &PSL::finalize)
         .function("public_suffix", &PSL::public_suffix)
-        .function("registrable_domain", &PSL::registrable_domain);
+        .function("registrable_domain", &PSL::registrable_domain)
+        .function("url_public_suffix", &PSL::url_public_suffix)
+        .function("url_registrable_domain", &PSL::url_registrable_domain);
 }

--- a/examples/url-demo/www/index.html
+++ b/examples/url-demo/www/index.html
@@ -40,6 +40,7 @@
     <tr class="search"><th>search</th><td></td></tr>
     <tr class="hash"><th>hash</th><td></td></tr>
     <tr class="origin"><th>origin</th><td></td></tr>
+    <tr class="domain" style="display:none"><th>registrable domain</th><td></td></tr>
   </table>
 
   <div id="url-error" class="output error"></div>

--- a/examples/url-demo/www/url-demo.js
+++ b/examples/url-demo/www/url-demo.js
@@ -42,7 +42,7 @@ function showResult(url) {
       const trComponent = output.querySelector(".domain");
       if (trComponent) {
         trComponent.querySelector("td").textContent =
-          public_suffix_list.registrable_domain(url.hostname);
+          public_suffix_list.url_registrable_domain(url);
       }
     }
   } else {


### PR DESCRIPTION
Use PSL to show [registrable domain](https://url.spec.whatwg.org/#host-registrable-domain).