### PR TITLE
Add workflow to compile with clang++ 7 and g++ 8

### DIFF
--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -29,9 +29,9 @@ jobs:
     - name: cmake
       run: cmake -S . -B build -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} ${{ matrix.cmake_options }}
     - name: build
-      run: cmake --build build --config Release
+      run: cmake --build build
     - name: test
-      run: ctest --test-dir build -C Release -V
+      run: ctest --test-dir build -V
     - name: after test
       if: ${{ matrix.after_test }}
       run: ${{ matrix.after_test }}

--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -113,6 +113,12 @@ jobs:
     strategy:
       matrix:
         include:
+          - name: clang++-7 C++17
+            container: silkeh/clang:7
+            cxx_standard: 17
+            cmake_options: "-DCMAKE_CXX_FLAGS=-stdlib=libc++"
+            install: "curl git"
+
           - name: g++-8 C++17
             container: gcc:8
             cxx_standard: 17
@@ -127,7 +133,9 @@ jobs:
     - uses: actions/checkout@v4
     - uses: lukka/get-cmake@v3.31.6
     - name: get dependencies
-      run: ./init.sh
+      run: |
+        git config --global --add safe.directory $(pwd)
+        ./init.sh
     - name: cmake
       run: cmake -S . -B build -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} ${{ matrix.cmake_options }}
     - name: build

--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -93,9 +93,9 @@ jobs:
     - name: cmake
       run: cmake -S . -B build -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} ${{ matrix.cmake_options }}
     - name: build
-      run: cmake --build build --config Release
+      run: cmake --build build
     - name: test
-      run: cd build ; ctest -C Release -V
+      run: cd build ; ctest -V
     - name: after test
       if: ${{ matrix.after_test }}
       run: ${{ matrix.after_test }}

--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -105,3 +105,32 @@ jobs:
         files: ./coverage.info
         token: ${{ secrets.CODECOV_TOKEN }}
         verbose: false
+
+  build_in_container:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    container: ${{ matrix.container }}
+    strategy:
+      matrix:
+        include:
+          - name: g++-8 C++17
+            container: gcc:8
+            cxx_standard: 17
+            cmake_options: ""
+
+    steps:
+    - name: apt-get install
+      if: ${{ matrix.install }}
+      run: |
+        apt-get update
+        apt-get install -y ${{ matrix.install }}
+    - uses: actions/checkout@v4
+    - uses: lukka/get-cmake@v3.31.6
+    - name: get dependencies
+      run: ./init.sh
+    - name: cmake
+      run: cmake -S . -B build -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} ${{ matrix.cmake_options }}
+    - name: build
+      run: cmake --build build
+    - name: test
+      run: cd build ; ctest -V


### PR DESCRIPTION
* Remove unnecessary cmake options from Ubuntu and macOS workflows
* Add workflow to compile with clang++ 7 and g++ 8
