### PR TITLE
Move code that accesses `public_suffix_list::root_` to .cpp file

### DIFF
--- a/include/upa/public_suffix_list.h
+++ b/include/upa/public_suffix_list.h
@@ -304,9 +304,15 @@ public:
     /// @brief Compares @c *this with @p other
     /// @param[in] other the public_suffix_list to compare with
     /// @return true if both lists are equal
-    bool operator==(const public_suffix_list& other) const {
-        return root_ == other.root_;
-    }
+    bool operator==(const public_suffix_list& other) const;
+
+    // constructors, destructor, assignment operators
+    public_suffix_list();
+    ~public_suffix_list();
+    public_suffix_list(public_suffix_list&&) noexcept;
+    public_suffix_list(const public_suffix_list&) = delete;
+    public_suffix_list& operator=(public_suffix_list&&) noexcept;
+    public_suffix_list& operator=(const public_suffix_list&) = delete;
 
 private:
     result get_host_suffix_info(std::string_view hostname, option opt) const;

--- a/src/public_suffix_list.cpp
+++ b/src/public_suffix_list.cpp
@@ -237,4 +237,13 @@ public_suffix_list::result public_suffix_list::get_host_suffix_info(
     return {};
 }
 
+bool public_suffix_list::operator==(const public_suffix_list& other) const {
+    return root_ == other.root_;
+}
+
+public_suffix_list::public_suffix_list() = default;
+public_suffix_list::~public_suffix_list() = default;
+public_suffix_list::public_suffix_list(public_suffix_list&&) noexcept = default;
+public_suffix_list& public_suffix_list::operator=(public_suffix_list&&) noexcept = default;
+
 } // namespace upa

--- a/test/test-public_suffix_list.cpp
+++ b/test/test-public_suffix_list.cpp
@@ -274,6 +274,49 @@ TEST_SUITE("public_suffix_list push interface") {
     }
 }
 
+TEST_SUITE("public_suffix_list::operator==") {
+    TEST_CASE("equal") {
+        upa::public_suffix_list psl1;
+        upa::public_suffix_list::push_context ctx1;
+        psl1.push_line(ctx1, "github.io");
+        psl1.push_line(ctx1, "examople.io");
+        upa::public_suffix_list psl2;
+        upa::public_suffix_list::push_context ctx2;
+        psl2.push_line(ctx2, "examople.io");
+        psl2.push_line(ctx2, "github.io");
+        CHECK(psl1 == psl2);
+    }
+    TEST_CASE("not equal") {
+        upa::public_suffix_list psl1;
+        upa::public_suffix_list::push_context ctx1;
+        psl1.push_line(ctx1, "github.io");
+        psl1.push_line(ctx1, "examople1.io");
+        upa::public_suffix_list psl2;
+        upa::public_suffix_list::push_context ctx2;
+        psl2.push_line(ctx2, "github.io");
+        psl2.push_line(ctx2, "examople2.io");
+        CHECK_FALSE(psl1 == psl2);
+    }
+}
+
+TEST_SUITE("public_suffix_list move construction and assignment") {
+    TEST_CASE("move construction") {
+        upa::public_suffix_list psl1;
+        upa::public_suffix_list::push_context ctx1;
+        psl1.push_line(ctx1, "github.io");
+        upa::public_suffix_list psl2{ std::move(psl1) };
+        CHECK(psl2.get_suffix("upa-url.github.io") == "github.io");
+    }
+    TEST_CASE("move assignment") {
+        upa::public_suffix_list psl1;
+        upa::public_suffix_list psl2;
+        upa::public_suffix_list::push_context ctx1;
+        psl1.push_line(ctx1, "github.io");
+        psl2 = std::move(psl1);
+        CHECK(psl2.get_suffix("upa-url.github.io") == "github.io");
+    }
+}
+
 int test_public_suffix_list_functions(int argc, char** argv) {
     std::cout << "========== Test public_suffix_list functions ==========\n";
 


### PR DESCRIPTION
The variable `root_` is of type `label_item` struct, containing a member named `children`. The type of `children` differs depending on whether the code is compiled with C++17 or C++20. It is possible to encounter a situation where the Upa URL library is compiled using a C++17 compiler, but is then integrated into a program compiled with C++20. In such cases, it is important that all code accessing `root_` is compiled using the same C++ standard, prompting the implementation of this fix.