### PR TITLE
Fix test-url_for_.cpp

### DIFF
--- a/test/test-url_for_.cpp
+++ b/test/test-url_for_.cpp
@@ -5,7 +5,10 @@
 
 #include "doctest-main.h"
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && \
+    __has_include(<atlsimpstr.h>) && \
+    __has_include(<atlstr.h>) && \
+    __has_include(<cstringt.h>)
 # define UPA_TEST_URL_FOR_ATL
 # include "upa/url_for_atl.h"
 # include <atlsimpstr.h>


### PR DESCRIPTION
Execute tests involving ATL/MFC string types if these libraries are installed. Verify their installation by checking for the presence of include files for their string types.