### PR TITLE
Add functions to get and check the shared library version

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -996,6 +996,7 @@ INPUT                  = include/upa/url.h \
                          include/upa/url_result.h \
                          include/upa/url_search_params.h \
                          include/upa/url_percent_encode.h \
+                         include/upa/url_version.h \
                          include/upa/public_suffix_list.h \
                          README.md \
                          doc/string_input.md

--- a/include/upa/url.h
+++ b/include/upa/url.h
@@ -3314,6 +3314,27 @@ template <class StrT, enable_if_str_arg_t<StrT> = 0>
     return path;
 }
 
+// Upa URL version functions
+
+/// @brief Get library version encoded to one number
+///
+/// For example, for the 2.1.0 version, it returns 0x00020100.
+///
+/// @return encoded version
+UPA_API std::uint32_t version_num();
+
+/// @brief Check used library version
+///
+/// Check that the Upa URL library used is compatible with the header
+/// files. This makes sense when using the shared Upa URL library.
+///
+/// @return true if they are compatible
+inline bool check_version() {
+    constexpr auto sover_mask = static_cast<std::uint32_t>(-1) ^
+        static_cast<std::uint32_t>(0xFF);
+    return (version_num() & sover_mask) ==
+        (static_cast<std::uint32_t>(UPA_URL_VERSION_NUM) & sover_mask);
+}
 
 } // namespace upa
 

--- a/include/upa/url_version.h
+++ b/include/upa/url_version.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2024 Rimas Misevičius
+// Copyright 2023-2025 Rimas Misevičius
 // Distributed under the BSD-style license that can be
 // found in the LICENSE file.
 //
@@ -13,6 +13,15 @@
 #define UPA_URL_VERSION_PATCH 0
 
 #define UPA_URL_VERSION "2.0.0"
+
+/// @brief Encode version to one number
+#define UPA_MAKE_VERSION_NUM(n1, n2, n3) ((n1) << 16 | (n2) << 8 | (n3))
+
+/// @brief Version encoded to one number
+#define UPA_URL_VERSION_NUM UPA_MAKE_VERSION_NUM( \
+    UPA_URL_VERSION_MAJOR, \
+    UPA_URL_VERSION_MINOR, \
+    UPA_URL_VERSION_PATCH)
 
 // NOLINTEND(*-macro-*)
 

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -102,5 +102,11 @@ const unsigned url::kPartFlagMask[url::PART_COUNT] = {
     FRAGMENT_FLAG
 };
 
+// Upa URL version encoded to one number
+
+std::uint32_t version_num() {
+    return UPA_URL_VERSION_NUM;
+}
+
 
 } // namespace upa

--- a/test/test-url.cpp
+++ b/test/test-url.cpp
@@ -924,3 +924,10 @@ TEST_CASE("url operator<<") {
     sout << upa::url{ input };
     CHECK(sout.str() == input);
 }
+
+// Test version
+
+TEST_CASE("Upa URL version") {
+    CHECK(upa::version_num() == UPA_URL_VERSION_NUM);
+    CHECK(upa::check_version());
+}


### PR DESCRIPTION
Adds two functions:
* `version_num()` - returns a one-number version of the used library.
* `check_version()` - returns `true` if the used library is compatible with the compiled program.