### PR TITLE
Add `fs_path_from_file_url` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Upa URL contains features not specified in the standard:
 1. The `upa::url` class has `path` getter (to get `pathname` concatenated with `search`)
 2. The `upa::url` class has the `get_part_pos` function to get the start and end position of the specified URL component in a URL string.
 3. Function to convert file system path to file URL: `upa::url_from_file_path`
-4. Function to get file system path from file URL: `upa::path_from_file_url`
+4. Functions to get file system path from file URL: `upa::path_from_file_url` and `upa::fs_path_from_file_url`
 5. Experimental URLHost class (see proposal: https://github.com/whatwg/url/pull/288): `upa::url_host`
 6. The `upa::url_search_params` class has a few additional functions: `remove`, `remove_if`
 

--- a/include/upa/url.h
+++ b/include/upa/url.h
@@ -3331,6 +3331,25 @@ template <class StrT, enable_if_str_arg_t<StrT> = 0>
     return path;
 }
 
+/// @brief Get OS path as std::filesystem::path from file URL
+///
+/// Throws url_error exception on error.
+///
+/// @param[in] file_url file URL
+/// @return OS path as std::filesystem::path
+[[nodiscard]] inline std::filesystem::path fs_path_from_file_url(const url& file_url) {
+#ifdef UPA_CPP_20
+    const std::string path_str = path_from_file_url(file_url);
+    // the path_str is encoded in UTF-8
+    const auto* first = reinterpret_cast<const char8_t*>(path_str.data());
+    const auto* last = first + path_str.size();
+    return { first, last, std::filesystem::path::native_format };
+#else
+    // the u8path is deprecated in C++20
+    return std::filesystem::u8path(path_from_file_url(file_url));
+#endif
+}
+
 // Upa URL version functions
 
 /// @brief Get library version encoded to one number

--- a/test/test-url.cpp
+++ b/test/test-url.cpp
@@ -907,6 +907,16 @@ TEST_CASE("path_from_file_url") {
     }
 }
 
+TEST_CASE("fs_path_from_file_url") {
+#ifdef _WIN32
+    const auto path = upa::fs_path_from_file_url(upa::url{ "file:///c:/dir/file-%C4%85-%C5%BE.txt" });
+    CHECK(path.u8string() == u8"c:\\dir\\file-\u0105-\u017E.txt");
+#else
+    const auto path = upa::fs_path_from_file_url(upa::url{ "file:///dir/file-%C4%85-%C5%BE.txt" });
+    CHECK(path.u8string() == u8"/dir/file-\u0105-\u017E.txt");
+#endif
+}
+
 // Test std::hash specialization and operator==
 
 TEST_CASE("std::hash<upa::url> and operator==") {


### PR DESCRIPTION
This function converts a file URL to an OS path of type `std::filesystem::path`.