### PR TITLE
Add the Visual Studio 2019 workflow to AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,6 +15,10 @@ environment:
       GENERATOR: Visual Studio 15 2017
       CXX_STANDARD: 17
 
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      GENERATOR: Visual Studio 16 2019
+      CXX_STANDARD: 17
+
 before_build:
   - init.bat
   - cmake -S . -B build -G "%GENERATOR%" -A x64 -DCMAKE_CXX_STANDARD="%CXX_STANDARD%"

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -14,18 +14,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: VS 2019 C++17
-            os: windows-2019
-            generator: "Visual Studio 16 2019"
-            cxx_standard: 17
-            cmake_options: ""
-
-          - name: VS 2019 C++20
-            os: windows-2019
-            generator: "Visual Studio 16 2019"
-            cxx_standard: 20
-            cmake_options: ""
-
           - name: VS 2022 C++17 shared-lib
             os: windows-2022
             generator: "Visual Studio 17 2022"


### PR DESCRIPTION
Remove all Visual Studio 2019 workflows from GitHub Actions because the Windows 2019 Actions runner image will be fully unsupported by 2025-06-30. See https://github.com/actions/runner-images/issues/12045