### PR TITLE
Use MSVC v142 (VS 2019 C++ build tools) with VS 2022

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,10 +15,6 @@ environment:
       GENERATOR: Visual Studio 15 2017
       CXX_STANDARD: 17
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      GENERATOR: Visual Studio 16 2019
-      CXX_STANDARD: 17
-
 before_build:
   - init.bat
   - cmake -S . -B build -G "%GENERATOR%" -A x64 -DCMAKE_CXX_STANDARD="%CXX_STANDARD%"

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -14,6 +14,18 @@ jobs:
     strategy:
       matrix:
         include:
+          - name: VS 2019 v142 C++17
+            os: windows-2022
+            generator: "Visual Studio 17 2022"
+            cxx_standard: 17
+            cmake_options: "-T v142"
+
+          - name: VS 2019 v142 C++20
+            os: windows-2022
+            generator: "Visual Studio 17 2022"
+            cxx_standard: 20
+            cmake_options: "-T v142"
+
           - name: VS 2022 C++17 shared-lib
             os: windows-2022
             generator: "Visual Studio 17 2022"


### PR DESCRIPTION
Revert commit 77e80bb5ff and modify VS 2019 jobs to use MSVC v142 with VS 2022.