### PR TITLE
Use another Docker image to fix errors when running `apt-get update`

### DIFF
--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -116,7 +116,7 @@ jobs:
           - name: clang++-7 C++17
             container: ubuntu:20.04
             cxx_standard: 17
-            cmake_options: "-DCMAKE_CXX_FLAGS=-stdlib=libc++"
+            cmake_options: "-G Ninja -DCMAKE_CXX_FLAGS=-stdlib=libc++"
             install: "curl git unzip clang-7 libc++-7-dev libc++abi-7-dev"
 
           - name: g++-8 C++17

--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -114,7 +114,7 @@ jobs:
       matrix:
         include:
           - name: clang++-7 C++17
-            container: silkeh/clang:7
+            container: teeks99/clang-ubuntu:7
             cxx_standard: 17
             cmake_options: "-DCMAKE_CXX_FLAGS=-stdlib=libc++"
             install: "curl git unzip"

--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -116,7 +116,7 @@ jobs:
           - name: clang++-7 C++17
             container: ubuntu:20.04
             cxx_standard: 17
-            cmake_options: "-G Ninja -DCMAKE_CXX_FLAGS=-stdlib=libc++"
+            cmake_options: "-G Ninja -DCMAKE_CXX_COMPILER=clang++-7 -DCMAKE_CXX_FLAGS=-stdlib=libc++"
             install: "curl git unzip clang-7 libc++-7-dev libc++abi-7-dev"
 
           - name: g++-8 C++17

--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -114,10 +114,10 @@ jobs:
       matrix:
         include:
           - name: clang++-7 C++17
-            container: teeks99/clang-ubuntu:7
+            container: ubuntu:20.04
             cxx_standard: 17
             cmake_options: "-DCMAKE_CXX_FLAGS=-stdlib=libc++"
-            install: "curl git unzip"
+            install: "curl git unzip clang-7 libc++-7-dev libc++abi-7-dev"
 
           - name: g++-8 C++17
             container: gcc:8


### PR DESCRIPTION
The `silkeh/clang:7` image began failing with the following error message: "404 Not Found [IP: 146.75.78.132:80]".
To fix this, the image changed to `ubuntu:20.4` and the `clang-7` compiler was additionally installed.