### PR TITLE
Fix unexpected stripping of default port in port canonicalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It is known to compile with Clang 7, GCC 8, Microsoft Visual Studio 2017 or late
 This library is up to date with the URL Standard published on
 [30 October 2025](https://url.spec.whatwg.org/commit-snapshots/52526653e848c5a56598c84aa4bc8ac9025fb66b/),
 the URL Pattern Standard published on
-[20 March 2026](https://urlpattern.spec.whatwg.org/commit-snapshots/203d435c32272a10bdccc2c6dfa8a51ee5c6b92c/)
+[15 June 2026](https://urlpattern.spec.whatwg.org/commit-snapshots/aeb2019cf3aa1fb31af134a682c0255302a41297/)
 and supports internationalized domain names as specified in the
 [UTS46 Unicode IDNA Compatibility Processing version 17.0.0](https://www.unicode.org/reports/tr46/tr46-35.html).
 

--- a/include/upa/urlpattern.h
+++ b/include/upa/urlpattern.h
@@ -2502,7 +2502,7 @@ inline std::string canonicalize_port(std::string_view port_value, std::optional<
         if (protocol_value)
             urls.set_scheme(*protocol_value);
         else
-            urls.set_scheme("https");
+            urls.set_scheme("");
         // Note, we set the URL record's scheme in order for the basic URL parser
         // to recognize and normalize default port values.
 

--- a/test/data/my-urlpatterntestdata.json
+++ b/test/data/my-urlpatterntestdata.json
@@ -10,16 +10,20 @@
   {
     "pattern": [{ "port": "443" }],
     "inputs": [{ "port": "443" }],
-    "exactly_empty_components": [ "port" ],
-    "expected_match": null
+    "expected_obj": {
+      "port": "443"
+    },
+    "expected_match": {
+      "port": { "input": "443", "groups": {}}
+    }
   },
   {
     "pattern": [{ "port": "443" }],
     "inputs": [{ "port": "" }],
-    "exactly_empty_components": [ "port" ],
-    "expected_match": {
-      "port": { "input": "", "groups": {}}
-    }
+    "expected_obj": {
+      "port": "443"
+    },
+    "expected_match": null
   },
   {
     "pattern": [{ "pathname": "path/.." }],

--- a/test/download-tests.bat
+++ b/test/download-tests.bat
@@ -17,7 +17,7 @@ REM Commit hash of URL Pattern web-platform-tests
 REM
 REM Run tools\update-wpt.py to update to the latest commit hash from
 REM https://github.com/web-platform-tests/wpt/tree/master/urlpattern
-set URLP_HASH=2f28df545cb4f16c99249b3db05c75495afeaaee
+set URLP_HASH=23aac9278460a73394585ff5a15b6a04dfcd5ec8
 
 for %%f in (urlpatterntestdata.json) do (
   curl -fsS -o %p%\wpt\%%f https://raw.githubusercontent.com/web-platform-tests/wpt/%URLP_HASH%/urlpattern/resources/%%f

--- a/test/download-tests.sh
+++ b/test/download-tests.sh
@@ -19,7 +19,7 @@ done
 #
 # Run tools/update-wpt.py to update to the latest commit hash from
 # https://github.com/web-platform-tests/wpt/tree/master/urlpattern
-URLP_HASH=2f28df545cb4f16c99249b3db05c75495afeaaee
+URLP_HASH=23aac9278460a73394585ff5a15b6a04dfcd5ec8
 
 for f in urlpatterntestdata.json
 do


### PR DESCRIPTION
Follows: https://github.com/whatwg/urlpattern/commit/aeb2019cf3aa1fb31af134a682c0255302a41297

Tests: https://github.com/web-platform-tests/wpt/commit/23aac9278460a73394585ff5a15b6a04dfcd5ec8